### PR TITLE
Fix Heroic Launcher game detection (#3)

### DIFF
--- a/src/scanner/game_scanner.py
+++ b/src/scanner/game_scanner.py
@@ -142,45 +142,121 @@ class GameScanner:
                 debug_log(f"Found Xbox path: {path}")
         return found_paths
 
-    def _find_heroic_paths(self):
-        """Find Heroic Launcher metadata directories."""
-        candidates = [
-            Path.home() / "AppData" / "Roaming" / "heroic",
-            Path.home() / "AppData" / "Local" / "heroic",
-        ]
-        found_paths = []
+    def _find_heroic_config_roots(self):
+        """Find Heroic Launcher config root directories (%APPDATA%/heroic)."""
+        candidates = []
+        for env_var in ("APPDATA", "LOCALAPPDATA"):
+            base = os.environ.get(env_var)
+            if base:
+                candidates.append(Path(base) / "heroic")
+        candidates.append(Path.home() / "AppData" / "Roaming" / "heroic")
+        candidates.append(Path.home() / "AppData" / "Local" / "heroic")
+
+        found_roots = []
+        seen = set()
         for base in candidates:
-            if not base.exists() or not base.is_dir():
+            key = str(base).lower()
+            if key in seen:
                 continue
-            for rel in ["GamesConfig", "legendaryConfig/legendary", "gog_store"]:
-                p = base / rel
-                if p.exists() and p.is_dir():
-                    found_paths.append(str(p))
-                    debug_log(f"Found Heroic path: {p}")
-        return found_paths
+            seen.add(key)
+            if base.is_dir():
+                found_roots.append(base)
+                debug_log(f"Found Heroic config root: {base}")
+        return found_roots
+
+    @staticmethod
+    def _read_json_file(path):
+        """Read a JSON file, returning None on any error."""
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (OSError, ValueError):
+            return None
+
+    def _heroic_installed_entries(self, root):
+        """Collect (title, install_path) pairs from a Heroic config root.
+
+        Heroic keeps one store file per backend:
+        - Epic:    legendaryConfig/legendary/installed.json — dict keyed by
+                   app_name, values carry title + install_path
+        - GOG:     gog_store/installed.json — {"installed": [{appName,
+                   install_path}]}; titles live in the library cache
+                   (store_cache/gog_library.json, older: gog_store/library.json)
+        - Amazon:  nile_config/nile/installed.json — [{id, path}]; titles in
+                   nile_config/nile/library.json
+        - Sideload: sideload_apps/library.json — {"games": [...]}
+        """
+        entries = []
+
+        data = self._read_json_file(root / "legendaryConfig" / "legendary" / "installed.json")
+        if isinstance(data, dict):
+            for meta in data.values():
+                if isinstance(meta, dict) and meta.get("install_path"):
+                    entries.append((meta.get("title"), meta["install_path"]))
+
+        gog_titles = {}
+        for lib_rel in (Path("store_cache") / "gog_library.json", Path("gog_store") / "library.json"):
+            lib = self._read_json_file(root / lib_rel)
+            if isinstance(lib, dict):
+                for game in lib.get("games") or []:
+                    if isinstance(game, dict):
+                        app = game.get("app_name") or game.get("appName")
+                        if app and game.get("title") and str(app) not in gog_titles:
+                            gog_titles[str(app)] = game["title"]
+        data = self._read_json_file(root / "gog_store" / "installed.json")
+        if isinstance(data, dict):
+            for meta in data.get("installed") or []:
+                if isinstance(meta, dict) and meta.get("install_path"):
+                    app = str(meta.get("appName") or meta.get("app_name") or "")
+                    entries.append((gog_titles.get(app), meta["install_path"]))
+
+        nile_dir = root / "nile_config" / "nile"
+        nile_titles = {}
+        lib = self._read_json_file(nile_dir / "library.json")
+        if isinstance(lib, list):
+            for game in lib:
+                if isinstance(game, dict):
+                    product = game.get("product") if isinstance(game.get("product"), dict) else {}
+                    title = game.get("title") or product.get("title")
+                    game_id = game.get("id") or product.get("id")
+                    if game_id and title:
+                        nile_titles[str(game_id)] = title
+        data = self._read_json_file(nile_dir / "installed.json")
+        if isinstance(data, list):
+            for meta in data:
+                if isinstance(meta, dict) and meta.get("path"):
+                    entries.append((nile_titles.get(str(meta.get("id"))), meta["path"]))
+
+        data = self._read_json_file(root / "sideload_apps" / "library.json")
+        if isinstance(data, dict):
+            for game in data.get("games") or []:
+                if not isinstance(game, dict) or game.get("is_installed") is False:
+                    continue
+                install = game.get("install") if isinstance(game.get("install"), dict) else {}
+                folder = game.get("folder_name")
+                if not folder and install.get("executable"):
+                    folder = str(Path(install["executable"]).parent)
+                if folder:
+                    entries.append((game.get("title"), folder))
+
+        return entries
 
     def _scan_heroic_games(self):
-        """Scan Heroic Launcher JSON configs for installed Epic/GOG games."""
+        """Scan Heroic Launcher configs for installed Epic/GOG/Amazon/sideloaded games."""
         games = []
+        seen_paths = set()
         try:
-            for root in self._find_heroic_paths():
-                root_path = Path(root)
-                for cfg in root_path.glob("*.json"):
+            for root in self._find_heroic_config_roots():
+                for title, install_path in self._heroic_installed_entries(root):
                     try:
-                        with open(cfg, "r", encoding="utf-8") as f:
-                            data = json.load(f)
-                        if not isinstance(data, dict):
-                            continue
-                        install = data.get("install") or {}
-                        install_path = install.get("install_path") or data.get("install_path")
-                        if not install_path:
-                            continue
-                        game_name = data.get("title") or data.get("name") or Path(install_path).name
-                        if not game_name:
-                            continue
                         p = Path(install_path)
-                        if not p.exists() or not self._is_game_folder(p):
+                        normalized = os.path.normpath(str(p)).lower()
+                        if normalized in seen_paths:
                             continue
+                        if not p.is_dir() or not self._is_game_folder(p):
+                            continue
+                        seen_paths.add(normalized)
+                        game_name = title or p.name.replace("_", " ").replace("-", " ")
                         image_path = self.fetch_game_image(game_name)
                         optiscaler_installed = self._detect_optiscaler(p)
                         safety = self.analyze_game_safety(Game(game_name, str(p)))
@@ -195,8 +271,9 @@ class GameScanner:
                             engine_supported=safety.get("engine_supported", True),
                             platform="Heroic"
                         ))
-                    except Exception:
-                        continue
+                        debug_log(f"Heroic: found '{game_name}' at {p}")
+                    except Exception as e:
+                        debug_log(f"Heroic: failed processing entry {install_path}: {e}")
         except Exception as e:
             debug_log(f"Heroic scan failed: {e}")
         return games

--- a/tests/test_heroic_scanner.py
+++ b/tests/test_heroic_scanner.py
@@ -1,0 +1,175 @@
+"""
+Tests for the Heroic Launcher scanner (issue #3).
+
+Builds a fake Heroic config tree covering all four backends
+(legendary/Epic, GOG, nile/Amazon, sideloaded) and verifies
+_scan_heroic_games finds the games with correct titles.
+"""
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scanner.game_scanner import GameScanner
+
+
+SAFETY = {
+    'engine': 'Unknown', 'anti_cheat_list': [],
+    'community_verified': False, 'engine_supported': True,
+}
+
+
+def _make_game_dir(base: Path, name: str) -> Path:
+    game_dir = base / name
+    game_dir.mkdir(parents=True)
+    (game_dir / "game.exe").touch()
+    return game_dir
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+@pytest.fixture
+def heroic_root(tmp_path):
+    """A Heroic config root populated with one game per backend."""
+    root = tmp_path / "heroic"
+    games_dir = tmp_path / "Games"
+
+    epic_dir = _make_game_dir(games_dir, "EpicGame")
+    _write_json(root / "legendaryConfig" / "legendary" / "installed.json", {
+        "epicapp1": {
+            "app_name": "epicapp1",
+            "title": "Epic Test Game",
+            "install_path": str(epic_dir),
+            "executable": "game.exe",
+        },
+    })
+
+    gog_dir = _make_game_dir(games_dir, "GogGame")
+    _write_json(root / "gog_store" / "installed.json", {
+        "installed": [
+            {"appName": "1207658930", "install_path": str(gog_dir), "platform": "windows"},
+        ],
+    })
+    _write_json(root / "store_cache" / "gog_library.json", {
+        "games": [
+            {"app_name": "1207658930", "title": "GOG Test Game"},
+        ],
+    })
+
+    amazon_dir = _make_game_dir(games_dir, "AmazonGame")
+    _write_json(root / "nile_config" / "nile" / "installed.json", [
+        {"id": "amzn1.adg.product.test", "path": str(amazon_dir), "version": "1.0"},
+    ])
+    _write_json(root / "nile_config" / "nile" / "library.json", [
+        {"id": "amzn1.adg.product.test", "product": {"title": "Amazon Test Game"}},
+    ])
+
+    sideload_dir = _make_game_dir(games_dir, "SideloadGame")
+    _write_json(root / "sideload_apps" / "library.json", {
+        "games": [
+            {
+                "app_name": "sideload1",
+                "title": "Sideload Test Game",
+                "is_installed": True,
+                "folder_name": str(sideload_dir),
+                "install": {"executable": str(sideload_dir / "game.exe"), "platform": "Windows"},
+            },
+        ],
+    })
+
+    return root
+
+
+def _scan(scanner: GameScanner, root: Path):
+    with patch.object(scanner, '_find_heroic_config_roots', return_value=[root]), \
+         patch.object(scanner, 'fetch_game_image', return_value=None), \
+         patch.object(scanner, '_detect_optiscaler', return_value=False), \
+         patch.object(scanner, '_is_game_folder', return_value=True), \
+         patch.object(scanner, 'analyze_game_safety', return_value=dict(SAFETY)):
+        return scanner._scan_heroic_games()
+
+
+def test_scans_all_heroic_backends(heroic_root):
+    games = _scan(GameScanner(), heroic_root)
+
+    names = sorted(g.name for g in games)
+    assert names == [
+        "Amazon Test Game",
+        "Epic Test Game",
+        "GOG Test Game",
+        "Sideload Test Game",
+    ]
+    assert all(g.platform == "Heroic" for g in games)
+    assert all(Path(g.path).is_dir() for g in games)
+
+
+def test_gog_title_falls_back_to_folder_name(tmp_path):
+    root = tmp_path / "heroic"
+    gog_dir = _make_game_dir(tmp_path / "Games", "Cyberpunk_2077")
+    _write_json(root / "gog_store" / "installed.json", {
+        "installed": [{"appName": "123", "install_path": str(gog_dir)}],
+    })
+
+    games = _scan(GameScanner(), root)
+
+    assert len(games) == 1
+    assert games[0].name == "Cyberpunk 2077"
+
+
+def test_older_gog_library_location_supplies_title(tmp_path):
+    root = tmp_path / "heroic"
+    gog_dir = _make_game_dir(tmp_path / "Games", "GogGame")
+    _write_json(root / "gog_store" / "installed.json", {
+        "installed": [{"appName": "42", "install_path": str(gog_dir)}],
+    })
+    _write_json(root / "gog_store" / "library.json", {
+        "games": [{"app_name": "42", "title": "Old Library Title"}],
+    })
+
+    games = _scan(GameScanner(), root)
+
+    assert [g.name for g in games] == ["Old Library Title"]
+
+
+def test_missing_install_dirs_are_skipped(tmp_path):
+    root = tmp_path / "heroic"
+    _write_json(root / "legendaryConfig" / "legendary" / "installed.json", {
+        "gone": {"title": "Uninstalled Game", "install_path": str(tmp_path / "does_not_exist")},
+    })
+
+    assert _scan(GameScanner(), root) == []
+
+
+def test_malformed_store_files_do_not_crash(tmp_path):
+    root = tmp_path / "heroic"
+    (root / "legendaryConfig" / "legendary").mkdir(parents=True)
+    (root / "legendaryConfig" / "legendary" / "installed.json").write_text("{not json", encoding="utf-8")
+    _write_json(root / "gog_store" / "installed.json", {"installed": "unexpected-type"})
+    _write_json(root / "sideload_apps" / "library.json", ["unexpected-type"])
+
+    assert _scan(GameScanner(), root) == []
+
+
+def test_same_install_path_reported_once(tmp_path):
+    root = tmp_path / "heroic"
+    game_dir = _make_game_dir(tmp_path / "Games", "SharedGame")
+    _write_json(root / "legendaryConfig" / "legendary" / "installed.json", {
+        "app1": {"title": "Shared Game", "install_path": str(game_dir)},
+    })
+    _write_json(root / "gog_store" / "installed.json", {
+        "installed": [{"appName": "9", "install_path": str(game_dir)}],
+    })
+
+    games = _scan(GameScanner(), root)
+
+    assert len(games) == 1
+    assert games[0].name == "Shared Game"
+
+
+def test_no_heroic_install_returns_empty(tmp_path):
+    games = _scan(GameScanner(), tmp_path / "nonexistent-heroic")
+    assert games == []


### PR DESCRIPTION
Fixes #3.

## Problem

The Heroic scanner shipped in v0.4.2 never found any games. It globbed `*.json` inside `GamesConfig`, `legendaryConfig/legendary` and `gog_store` and expected each file to be a single game object with a top-level `install_path` — but none of Heroic's store files have that shape, so every file was silently skipped. This is why "Cannot locate games installed via heroic launcher" was still reproducible.

## Fix

Parse Heroic's actual per-backend store files (verified against the Heroic Games Launcher source):

| Backend | File | Shape |
|---|---|---|
| Epic (legendary) | `legendaryConfig/legendary/installed.json` | dict keyed by app_name with `title` + `install_path` |
| GOG | `gog_store/installed.json` | `{"installed": [{appName, install_path}]}`; titles from `store_cache/gog_library.json` (or the older `gog_store/library.json`) |
| Amazon (nile) | `nile_config/nile/installed.json` | `[{id, path}]`; titles from `library.json` |
| Sideloaded | `sideload_apps/library.json` | `{"games": [{title, folder_name, install}]}` |

Additional hardening:
- Heroic config root resolved via `APPDATA`/`LOCALAPPDATA` env vars with `Path.home()` fallback
- Entries pointing at the same install directory are deduped (e.g. a game visible to two backends)
- Malformed/missing store files are skipped without aborting the scan
- Titles fall back to a cleaned-up folder name when the library cache is absent

## Testing

- 7 new tests in `tests/test_heroic_scanner.py` covering all four backends, both GOG library locations, title fallback, dedup, malformed JSON, and no-Heroic machines — full suite: **17 passed**
- End-to-end run of the real scanner (real `_is_game_folder`, real safety analysis) against a realistic fixture tree: both games found with `platform="Heroic"`
- Real-machine sanity run without Heroic installed: 0 games, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)