### PR TITLE
Rust rewrite M1: core scan with full Python parity (28/28 games, 0.19s)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1061,6 +1061,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,9 +1640,12 @@ name = "opticore"
 version = "2026.7.0-alpha.1"
 dependencies = [
  "hex",
+ "serde",
+ "serde_json",
  "sevenz-rust2",
  "sha2",
  "tempfile",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2004,6 +2013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2024,6 +2034,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2742,8 +2765,8 @@ checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -2776,6 +2799,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,13 +2819,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3152,6 +3204,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"

--- a/rust/crates/opticore/Cargo.toml
+++ b/rust/crates/opticore/Cargo.toml
@@ -9,6 +9,11 @@ repository.workspace = true
 [dependencies]
 sevenz-rust2 = "0.21"
 sha2 = "0.11"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[target.'cfg(windows)'.dependencies]
+windows-registry = "0.6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/crates/opticore/examples/scan_cli.rs
+++ b/rust/crates/opticore/examples/scan_cli.rs
@@ -1,0 +1,44 @@
+//! Dev harness: run a full scan against the real machine and print the
+//! results — used to verify M1 parity against the Python app's game list.
+//!
+//! Usage: cargo run --release -p opticore --example scan_cli
+
+use opticore::scan::{scan_all, ScanConfig};
+use std::collections::BTreeMap;
+use std::time::Instant;
+
+fn main() {
+    let t0 = Instant::now();
+    let result = scan_all(&ScanConfig::default());
+    let elapsed = t0.elapsed();
+
+    let mut games = result.games;
+    games.sort_by(|a, b| {
+        (a.platform.label(), a.key.name_lower.clone())
+            .cmp(&(b.platform.label(), b.key.name_lower.clone()))
+    });
+
+    let mut per_platform: BTreeMap<&str, usize> = BTreeMap::new();
+    for g in &games {
+        *per_platform.entry(g.platform.label()).or_default() += 1;
+    }
+
+    for g in &games {
+        println!(
+            "{}|{}|{}|engine={:?}|appid={}|optiscaler={}|anticheat={:?}",
+            g.platform.label(),
+            g.name,
+            g.path.display(),
+            g.engine,
+            g.steam_appid.map(|a| a.to_string()).unwrap_or_default(),
+            g.optiscaler_installed,
+            g.anti_cheat,
+        );
+    }
+    println!(
+        "RESULT games={} time={:.2}s platforms={:?}",
+        games.len(),
+        elapsed.as_secs_f32(),
+        per_platform
+    );
+}

--- a/rust/crates/opticore/src/lib.rs
+++ b/rust/crates/opticore/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod archive;
 pub mod model;
+pub mod scan;
 
 /// App version (CalVer), single source of truth for the workspace.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/rust/crates/opticore/src/scan/discovery.rs
+++ b/rust/crates/opticore/src/scan/discovery.rs
@@ -1,0 +1,76 @@
+//! Native library-root discovery: fixed-drive probing for well-known game
+//! library folders. Replaces the Python app's PowerShell discovery pipeline
+//! (registry + drive enumeration run in milliseconds natively, so no cache).
+
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootKind {
+    Steam,
+    Epic,
+    Gog,
+    Xbox,
+}
+
+#[derive(Debug, Clone)]
+pub struct LibraryRoot {
+    pub kind: RootKind,
+    pub path: PathBuf,
+}
+
+/// Well-known library folder names probed on every fixed drive.
+const DRIVE_PATTERNS: &[(RootKind, &str)] = &[
+    (RootKind::Steam, "SteamLibrary"),
+    (RootKind::Steam, r"Games\SteamLibrary"),
+    (RootKind::Xbox, "XboxGames"),
+    (RootKind::Epic, "Epic Games"),
+    (RootKind::Gog, "GOG Games"),
+    (RootKind::Gog, r"GOG Galaxy\Games"),
+];
+
+/// Drive letters present on the system (fixed or otherwise reachable).
+fn drive_roots() -> Vec<PathBuf> {
+    ('A'..='Z')
+        .map(|letter| PathBuf::from(format!("{letter}:\\")))
+        .filter(|p| p.is_dir())
+        .collect()
+}
+
+/// Probe all drives for well-known game library folders, skipping excluded
+/// drive letters (uppercase, no colon — mirrors the Python config format).
+pub fn discover_roots(excluded_drives: &[char]) -> Vec<LibraryRoot> {
+    let mut found = Vec::new();
+    for drive in drive_roots() {
+        let letter = drive
+            .to_string_lossy()
+            .chars()
+            .next()
+            .unwrap_or('?')
+            .to_ascii_uppercase();
+        if excluded_drives.contains(&letter) {
+            continue;
+        }
+        for (kind, pattern) in DRIVE_PATTERNS {
+            let candidate = drive.join(pattern);
+            if candidate.is_dir() {
+                found.push(LibraryRoot {
+                    kind: *kind,
+                    path: candidate,
+                });
+            }
+        }
+    }
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn excluded_drives_are_skipped() {
+        // Excluding every letter must yield nothing, regardless of machine state.
+        let all: Vec<char> = ('A'..='Z').collect();
+        assert!(discover_roots(&all).is_empty());
+    }
+}

--- a/rust/crates/opticore/src/scan/epic.rs
+++ b/rust/crates/opticore/src/scan/epic.rs
@@ -1,0 +1,89 @@
+//! Epic Games metadata helpers. Port of `_read_epic_game_name` and the
+//! .egstore/.mancfg install markers.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+/// Known Epic install roots.
+pub fn default_roots() -> Vec<std::path::PathBuf> {
+    [
+        r"C:\Program Files\Epic Games",
+        r"C:\Program Files (x86)\Epic Games",
+    ]
+    .iter()
+    .map(std::path::PathBuf::from)
+    .filter(|p| p.is_dir())
+    .collect()
+}
+
+/// True if the folder carries Epic install metadata.
+pub fn has_epic_markers(game_folder: &Path) -> bool {
+    if game_folder.join(".egstore").exists() {
+        return true;
+    }
+    mancfg_files(game_folder).next().is_some()
+}
+
+fn mancfg_files(dir: &Path) -> impl Iterator<Item = std::path::PathBuf> {
+    fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|e| e == "mancfg").unwrap_or(false))
+}
+
+/// Read the real game title from Epic metadata (DisplayName / AppName in
+/// .egstore/*.mancfg or top-level *.mancfg). Empty result → caller falls
+/// back to a prettified folder name.
+pub fn read_game_name(game_folder: &Path) -> Option<String> {
+    let egstore = game_folder.join(".egstore");
+    let candidates = mancfg_files(&egstore).chain(mancfg_files(game_folder));
+    for mf in candidates {
+        let Ok(content) = fs::read_to_string(&mf) else {
+            continue;
+        };
+        let Ok(data) = serde_json::from_str::<Value>(&content) else {
+            continue;
+        };
+        let title = data
+            .get("DisplayName")
+            .or_else(|| data.get("AppName"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if title.len() > 1 {
+            return Some(title.trim().to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_display_name_from_egstore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("SomeGame");
+        let egstore = game.join(".egstore");
+        fs::create_dir_all(&egstore).unwrap();
+        fs::write(
+            egstore.join("abc.mancfg"),
+            r#"{"DisplayName": "Some Game: Deluxe"}"#,
+        )
+        .unwrap();
+        assert!(has_epic_markers(&game));
+        assert_eq!(read_game_name(&game).as_deref(), Some("Some Game: Deluxe"));
+    }
+
+    #[test]
+    fn missing_metadata_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("Bare");
+        fs::create_dir_all(&game).unwrap();
+        assert!(!has_epic_markers(&game));
+        assert!(read_game_name(&game).is_none());
+    }
+}

--- a/rust/crates/opticore/src/scan/folder_facts.rs
+++ b/rust/crates/opticore/src/scan/folder_facts.rs
@@ -1,0 +1,318 @@
+//! Single-pass bounded folder walk feeding all per-game detectors.
+//! Port of the Python `FolderFacts` / `_collect_folder_facts` design
+//! (one traversal per game folder instead of 3–4).
+
+use crate::model::{AntiCheat, Engine};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const MAX_SCAN_DEPTH: usize = 3;
+pub const MAX_FILES_TO_CHECK: usize = 1000;
+
+/// File suffixes that indicate significant game content.
+const GAME_CONTENT_SUFFIXES: &[&str] = &[".pak", ".uasset", ".dll", ".bin", ".unity3d"];
+
+/// Common non-game folder names excluded from game detection
+/// (matched as substrings of the folder name, case-insensitive).
+const EXCLUDE_FOLDERS: &[&str] = &[
+    "_commonredist",
+    "redist",
+    "sdk",
+    "tools",
+    "server",
+    "addons",
+    "dlc",
+    "soundtrack",
+    "artbook",
+    "manuals",
+    "bonuscontent",
+    "support",
+    "installer",
+];
+
+/// OptiScaler indicator files (port of `OPTISCALER_INDICATOR_FILES`).
+const OPTISCALER_FILES: &[&str] = &[
+    "nvngx_dlss.dll",
+    "nvngx_dlssg.dll",
+    "optiscaler.dll",
+    "nvngx.dll",
+    "dxgi.dll",
+    "winmm.dll",
+];
+const OPTISCALER_SUBDIRS: &[&str] = &["D3D12_Optiscaler", "OptiScaler", "mods", "plugins"];
+
+#[derive(Debug, Default)]
+pub struct FolderFacts {
+    pub root: PathBuf,
+    /// Lowercase file names directly in the folder.
+    pub top_files: Vec<String>,
+    /// Lowercase directory names directly in the folder.
+    pub top_dirs: Vec<String>,
+    /// Lowercase file names in direct child directories.
+    pub depth1_files: Vec<String>,
+    pub file_count: usize,
+    pub found_exe: bool,
+    pub found_game_content: bool,
+}
+
+/// Walk `root` up to MAX_SCAN_DEPTH / MAX_FILES_TO_CHECK, collecting facts.
+/// Returns None if the folder can't be read at all.
+pub fn collect(root: &Path) -> Option<FolderFacts> {
+    let mut facts = FolderFacts {
+        root: root.to_path_buf(),
+        ..Default::default()
+    };
+    if walk(root, 0, &mut facts).is_err() && facts.file_count == 0 && facts.top_dirs.is_empty() {
+        return None;
+    }
+    Some(facts)
+}
+
+fn walk(dir: &Path, depth: usize, facts: &mut FolderFacts) -> std::io::Result<()> {
+    let entries = fs::read_dir(dir)?;
+    let in_unreal_dir = dir
+        .to_string_lossy()
+        .to_lowercase()
+        .contains("unrealengine");
+    let mut subdirs: Vec<PathBuf> = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        let name_lower = entry.file_name().to_string_lossy().to_lowercase();
+        if ft.is_dir() {
+            if depth == 0 {
+                facts.top_dirs.push(name_lower);
+            }
+            subdirs.push(entry.path());
+        } else {
+            facts.file_count += 1;
+            if facts.file_count > MAX_FILES_TO_CHECK {
+                return Ok(());
+            }
+            if depth == 0 {
+                facts.top_files.push(name_lower.clone());
+            } else if depth == 1 {
+                facts.depth1_files.push(name_lower.clone());
+            }
+            if name_lower.ends_with(".exe") {
+                facts.found_exe = true;
+            }
+            if GAME_CONTENT_SUFFIXES
+                .iter()
+                .any(|s| name_lower.ends_with(s))
+                || in_unreal_dir
+            {
+                facts.found_game_content = true;
+            }
+        }
+    }
+    // Python's walker visits directories while relpath.count(sep) < max_scan_depth,
+    // i.e. dirs up to MAX_SCAN_DEPTH levels below root (files one level deeper
+    // still get read). depth here is 1-based for children of root.
+    if depth < MAX_SCAN_DEPTH {
+        for sub in subdirs {
+            if facts.file_count > MAX_FILES_TO_CHECK {
+                break;
+            }
+            // Ignore unreadable subdirectories, matching the Python walker
+            let _ = walk(&sub, depth + 1, facts);
+        }
+    }
+    Ok(())
+}
+
+/// Game-folder heuristic: exe or game content present, and more than 5 files.
+/// The folder's own name must not match the exclusion list.
+pub fn is_game_folder(root: &Path, facts: &FolderFacts) -> bool {
+    let folder_name = root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+    if EXCLUDE_FOLDERS.iter().any(|ex| folder_name.contains(ex)) {
+        return false;
+    }
+    (facts.found_exe || facts.found_game_content) && facts.file_count > 5
+}
+
+/// Engine detection. Port of `_detect_engine_type`.
+pub fn detect_engine(root: &Path, facts: &FolderFacts) -> Engine {
+    if root.join("Engine").join("Binaries").join("Win64").is_dir() {
+        return Engine::Unreal;
+    }
+    if facts.top_files.iter().any(|f| f == "unityplayer.dll")
+        || facts.top_dirs.iter().any(|d| d == "assets")
+    {
+        return Engine::Unity;
+    }
+    if facts.top_files.iter().any(|f| f.ends_with(".godot"))
+        || facts.top_dirs.iter().any(|d| d == ".import")
+    {
+        return Engine::Godot;
+    }
+    for name in &facts.top_files {
+        if name.ends_with(".exe") {
+            let squeezed: String = name.chars().filter(|c| *c != ' ').collect();
+            if name.contains("prism")
+                || (name.contains("euro") && name.contains("truck"))
+                || name.contains("ats")
+                || squeezed.contains("eurotruck")
+            {
+                return Engine::Prism3D;
+            }
+        } else if name.ends_with(".dll")
+            && (name.contains("prism") || name.contains("prism3d") || name.contains("scs"))
+        {
+            return Engine::Prism3D;
+        }
+    }
+    const PRISM_CONFIGS: &[&str] = &[
+        "prismengine.ini",
+        "engine.ini",
+        "scs_game.ini",
+        "scs_game.txt",
+    ];
+    if facts
+        .top_files
+        .iter()
+        .any(|f| PRISM_CONFIGS.contains(&f.as_str()))
+    {
+        return Engine::Prism3D;
+    }
+    Engine::Unknown
+}
+
+/// Engines OptiScaler installs are known to work with.
+/// Port of `compatibility_checker.supported_engines`.
+pub fn is_engine_supported(engine: Engine) -> bool {
+    matches!(engine, Engine::Unreal | Engine::Unity | Engine::Godot)
+}
+
+/// Anti-cheat detection over top-level names + direct-child file names.
+/// Port of `_detect_anti_cheat` (post-v0.5.2 semantics).
+pub fn detect_anti_cheat(facts: &FolderFacts) -> Vec<AntiCheat> {
+    let indicators: &[(AntiCheat, &[&str])] = &[
+        (
+            AntiCheat::EasyAntiCheat,
+            &["easyanticheat.sys", "easyanticheat.exe", "easyanticheat"],
+        ),
+        (
+            AntiCheat::BattlEye,
+            &["beclient.dll", "beservice.exe", "battleye"],
+        ),
+        (AntiCheat::Vanguard, &["vgc.sys", "vgtray.exe", "vanguard"]),
+    ];
+    let candidates = facts
+        .top_files
+        .iter()
+        .chain(facts.top_dirs.iter())
+        .chain(facts.depth1_files.iter());
+    let mut found = Vec::new();
+    for name in candidates {
+        for (ac, patterns) in indicators {
+            if !found.contains(ac) && patterns.iter().any(|p| name.contains(p)) {
+                found.push(*ac);
+            }
+        }
+    }
+    found
+}
+
+/// Detect an existing OptiScaler install. Port of `_detect_optiscaler`.
+pub fn detect_optiscaler(root: &Path, facts: &FolderFacts) -> bool {
+    if facts
+        .top_files
+        .iter()
+        .any(|f| OPTISCALER_FILES.contains(&f.as_str()))
+    {
+        return true;
+    }
+    let subdirs_present: Vec<&&str> = OPTISCALER_SUBDIRS
+        .iter()
+        .filter(|s| facts.top_dirs.iter().any(|d| d == &s.to_lowercase()))
+        .collect();
+    for subdir in subdirs_present {
+        let sub = root.join(subdir);
+        if OPTISCALER_FILES.iter().any(|f| sub.join(f).exists()) {
+            return true;
+        }
+    }
+    let ue_dir = root.join("Engine").join("Binaries").join("Win64");
+    if ue_dir.is_dir() {
+        if OPTISCALER_FILES.iter().any(|f| ue_dir.join(f).exists()) {
+            return true;
+        }
+        for subdir in OPTISCALER_SUBDIRS {
+            let sub = ue_dir.join(subdir);
+            if sub.is_dir() && OPTISCALER_FILES.iter().any(|f| sub.join(f).exists()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+
+    fn make_unity_game(base: &Path, name: &str) -> PathBuf {
+        let d = base.join(name);
+        fs::create_dir_all(d.join("Data")).unwrap();
+        File::create(d.join(format!("{name}.exe"))).unwrap();
+        File::create(d.join("UnityPlayer.dll")).unwrap();
+        for i in 0..6 {
+            File::create(d.join("Data").join(format!("data{i}.bin"))).unwrap();
+        }
+        fs::create_dir_all(d.join("EasyAntiCheat")).unwrap();
+        File::create(d.join("EasyAntiCheat").join("EasyAntiCheat.exe")).unwrap();
+        d
+    }
+
+    #[test]
+    fn facts_feed_all_detectors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = make_unity_game(tmp.path(), "FactsGame");
+        let facts = collect(&game).unwrap();
+        assert!(facts.found_exe);
+        assert!(facts.found_game_content);
+        assert!(facts.file_count > 5);
+        assert!(is_game_folder(&game, &facts));
+        assert_eq!(detect_engine(&game, &facts), Engine::Unity);
+        assert!(detect_anti_cheat(&facts).contains(&AntiCheat::EasyAntiCheat));
+        assert!(!detect_optiscaler(&game, &facts));
+
+        File::create(game.join("dxgi.dll")).unwrap();
+        let facts2 = collect(&game).unwrap();
+        assert!(detect_optiscaler(&game, &facts2));
+    }
+
+    #[test]
+    fn excluded_folder_names_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = make_unity_game(tmp.path(), "Redist");
+        let facts = collect(&d).unwrap();
+        assert!(!is_game_folder(&d, &facts));
+    }
+
+    #[test]
+    fn unreal_detection_via_engine_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = tmp.path().join("UeGame");
+        fs::create_dir_all(d.join("Engine").join("Binaries").join("Win64")).unwrap();
+        File::create(d.join("UeGame.exe")).unwrap();
+        let facts = collect(&d).unwrap();
+        assert_eq!(detect_engine(&d, &facts), Engine::Unreal);
+        assert!(is_engine_supported(Engine::Unreal));
+        assert!(!is_engine_supported(Engine::Unknown));
+    }
+
+    #[test]
+    fn small_folders_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = tmp.path().join("Tiny");
+        fs::create_dir_all(&d).unwrap();
+        File::create(d.join("app.exe")).unwrap();
+        let facts = collect(&d).unwrap();
+        assert!(!is_game_folder(&d, &facts)); // ≤5 files
+    }
+}

--- a/rust/crates/opticore/src/scan/gog.rs
+++ b/rust/crates/opticore/src/scan/gog.rs
@@ -1,0 +1,57 @@
+//! GOG metadata helpers: goggame-*.info gameTitle lookup.
+
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Known GOG install roots.
+pub fn default_roots() -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = vec![PathBuf::from(r"C:\Program Files (x86)\GOG Galaxy\Games")];
+    if let Some(home) = std::env::var_os("USERPROFILE") {
+        roots.push(PathBuf::from(home).join("GOG Games"));
+    }
+    roots.into_iter().filter(|p| p.is_dir()).collect()
+}
+
+/// Read `gameTitle` from the first goggame-*.info file in the folder.
+pub fn read_game_title(game_folder: &Path) -> Option<String> {
+    let entries = fs::read_dir(game_folder).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with("goggame-") && name.ends_with(".info") {
+            let content = fs::read_to_string(entry.path()).ok()?;
+            let data: Value = serde_json::from_str(&content).ok()?;
+            if let Some(title) = data.get("gameTitle").and_then(Value::as_str) {
+                return Some(title.to_string());
+            }
+            return None;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_game_title() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("cp2077");
+        fs::create_dir_all(&game).unwrap();
+        fs::write(
+            game.join("goggame-1091500.info"),
+            r#"{"gameTitle": "Cyberpunk 2077"}"#,
+        )
+        .unwrap();
+        assert_eq!(read_game_title(&game).as_deref(), Some("Cyberpunk 2077"));
+    }
+
+    #[test]
+    fn missing_info_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("bare");
+        fs::create_dir_all(&game).unwrap();
+        assert!(read_game_title(&game).is_none());
+    }
+}

--- a/rust/crates/opticore/src/scan/heroic.rs
+++ b/rust/crates/opticore/src/scan/heroic.rs
@@ -1,0 +1,244 @@
+//! Heroic Games Launcher store parsing. Direct port of the Python
+//! `_heroic_installed_entries` (v0.5.1) — one store file per backend:
+//! - Epic: legendaryConfig/legendary/installed.json (dict by app_name)
+//! - GOG: gog_store/installed.json + title cache (store_cache/gog_library.json
+//!   or the older gog_store/library.json)
+//! - Amazon: nile_config/nile/installed.json + library.json
+//! - Sideload: sideload_apps/library.json
+
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// (title, install_path) — title is None when only the folder name is known.
+pub type HeroicEntry = (Option<String>, PathBuf);
+
+fn read_json(path: &Path) -> Option<Value> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Existing Heroic config roots (%APPDATA%/heroic, %LOCALAPPDATA%/heroic).
+pub fn config_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for var in ["APPDATA", "LOCALAPPDATA"] {
+        if let Some(base) = std::env::var_os(var) {
+            let candidate = PathBuf::from(base).join("heroic");
+            let key = candidate.to_string_lossy().to_lowercase();
+            if candidate.is_dir() && seen.insert(key) {
+                roots.push(candidate);
+            }
+        }
+    }
+    roots
+}
+
+/// Collect (title, install_path) pairs from one Heroic config root.
+pub fn installed_entries(root: &Path) -> Vec<HeroicEntry> {
+    let mut entries = Vec::new();
+
+    // Epic games via Heroic's bundled legendary
+    if let Some(Value::Object(map)) = read_json(
+        &root
+            .join("legendaryConfig")
+            .join("legendary")
+            .join("installed.json"),
+    ) {
+        for meta in map.values() {
+            if let Some(install_path) = meta.get("install_path").and_then(Value::as_str) {
+                let title = meta.get("title").and_then(Value::as_str).map(String::from);
+                entries.push((title, PathBuf::from(install_path)));
+            }
+        }
+    }
+
+    // GOG titles from the library cache (newer then older location)
+    let mut gog_titles: HashMap<String, String> = HashMap::new();
+    for lib_rel in [
+        root.join("store_cache").join("gog_library.json"),
+        root.join("gog_store").join("library.json"),
+    ] {
+        if let Some(lib) = read_json(&lib_rel) {
+            for game in lib
+                .get("games")
+                .and_then(Value::as_array)
+                .unwrap_or(&Vec::new())
+            {
+                let app = game
+                    .get("app_name")
+                    .or_else(|| game.get("appName"))
+                    .and_then(Value::as_str);
+                let title = game.get("title").and_then(Value::as_str);
+                if let (Some(app), Some(title)) = (app, title) {
+                    gog_titles
+                        .entry(app.to_string())
+                        .or_insert_with(|| title.to_string());
+                }
+            }
+        }
+    }
+    if let Some(data) = read_json(&root.join("gog_store").join("installed.json")) {
+        for meta in data
+            .get("installed")
+            .and_then(Value::as_array)
+            .unwrap_or(&Vec::new())
+        {
+            if let Some(install_path) = meta.get("install_path").and_then(Value::as_str) {
+                let app = meta
+                    .get("appName")
+                    .or_else(|| meta.get("app_name"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                entries.push((gog_titles.get(app).cloned(), PathBuf::from(install_path)));
+            }
+        }
+    }
+
+    // Amazon games via nile
+    let nile_dir = root.join("nile_config").join("nile");
+    let mut nile_titles: HashMap<String, String> = HashMap::new();
+    if let Some(Value::Array(lib)) = read_json(&nile_dir.join("library.json")) {
+        for game in &lib {
+            let product = game.get("product");
+            let title = game
+                .get("title")
+                .and_then(Value::as_str)
+                .or_else(|| product.and_then(|p| p.get("title")).and_then(Value::as_str));
+            let id = game
+                .get("id")
+                .and_then(Value::as_str)
+                .or_else(|| product.and_then(|p| p.get("id")).and_then(Value::as_str));
+            if let (Some(id), Some(title)) = (id, title) {
+                nile_titles.insert(id.to_string(), title.to_string());
+            }
+        }
+    }
+    if let Some(Value::Array(installed)) = read_json(&nile_dir.join("installed.json")) {
+        for meta in &installed {
+            if let Some(path) = meta.get("path").and_then(Value::as_str) {
+                let title = meta
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .and_then(|id| nile_titles.get(id).cloned());
+                entries.push((title, PathBuf::from(path)));
+            }
+        }
+    }
+
+    // Sideloaded apps
+    if let Some(data) = read_json(&root.join("sideload_apps").join("library.json")) {
+        for game in data
+            .get("games")
+            .and_then(Value::as_array)
+            .unwrap_or(&Vec::new())
+        {
+            if game.get("is_installed").and_then(Value::as_bool) == Some(false) {
+                continue;
+            }
+            let folder = game
+                .get("folder_name")
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+                .or_else(|| {
+                    game.get("install")
+                        .and_then(|i| i.get("executable"))
+                        .and_then(Value::as_str)
+                        .and_then(|exe| PathBuf::from(exe).parent().map(Path::to_path_buf))
+                });
+            if let Some(folder) = folder {
+                let title = game.get("title").and_then(Value::as_str).map(String::from);
+                entries.push((title, folder));
+            }
+        }
+    }
+
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_json(path: &Path, content: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn parses_all_four_backends() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("heroic");
+
+        write_json(
+            &root
+                .join("legendaryConfig")
+                .join("legendary")
+                .join("installed.json"),
+            r#"{"app1": {"title": "Epic Game", "install_path": "C:\\Games\\Epic"}}"#,
+        );
+        write_json(
+            &root.join("gog_store").join("installed.json"),
+            r#"{"installed": [{"appName": "42", "install_path": "C:\\Games\\Gog"}]}"#,
+        );
+        write_json(
+            &root.join("store_cache").join("gog_library.json"),
+            r#"{"games": [{"app_name": "42", "title": "GOG Game"}]}"#,
+        );
+        write_json(
+            &root.join("nile_config").join("nile").join("installed.json"),
+            r#"[{"id": "amzn1", "path": "C:\\Games\\Amazon"}]"#,
+        );
+        write_json(
+            &root.join("nile_config").join("nile").join("library.json"),
+            r#"[{"id": "amzn1", "product": {"title": "Amazon Game"}}]"#,
+        );
+        write_json(
+            &root.join("sideload_apps").join("library.json"),
+            r#"{"games": [{"title": "Side Game", "is_installed": true, "folder_name": "C:\\Games\\Side"}]}"#,
+        );
+
+        let mut titles: Vec<Option<String>> = installed_entries(&root)
+            .into_iter()
+            .map(|(t, _)| t)
+            .collect();
+        titles.sort();
+        assert_eq!(titles.len(), 4);
+        assert!(titles.contains(&Some("Epic Game".into())));
+        assert!(titles.contains(&Some("GOG Game".into())));
+        assert!(titles.contains(&Some("Amazon Game".into())));
+        assert!(titles.contains(&Some("Side Game".into())));
+    }
+
+    #[test]
+    fn gog_title_missing_yields_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("heroic");
+        write_json(
+            &root.join("gog_store").join("installed.json"),
+            r#"{"installed": [{"appName": "7", "install_path": "C:\\G\\NoTitle"}]}"#,
+        );
+        let entries = installed_entries(&root);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].0.is_none());
+    }
+
+    #[test]
+    fn uninstalled_sideload_skipped_and_malformed_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("heroic");
+        write_json(
+            &root.join("sideload_apps").join("library.json"),
+            r#"{"games": [{"title": "Gone", "is_installed": false, "folder_name": "C:\\G\\Gone"}]}"#,
+        );
+        write_json(
+            &root
+                .join("legendaryConfig")
+                .join("legendary")
+                .join("installed.json"),
+            "{not valid json",
+        );
+        assert!(installed_entries(&root).is_empty());
+    }
+}

--- a/rust/crates/opticore/src/scan/mod.rs
+++ b/rust/crates/opticore/src/scan/mod.rs
@@ -1,0 +1,457 @@
+//! Scan orchestration: runs all platform scanners, dedups results, and
+//! filters launcher/redistributable entries — the Rust port of the Python
+//! `GameScanner.scan_games` flow (post-v0.5.2 semantics: each Steam library
+//! scanned once, one folder walk per game, no image fetching here).
+
+pub mod discovery;
+pub mod epic;
+pub mod folder_facts;
+pub mod gog;
+pub mod heroic;
+pub mod names;
+pub mod steam;
+pub mod xbox;
+
+use crate::model::{Game, GameKey, Platform};
+use discovery::{LibraryRoot, RootKind};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Default, Clone)]
+pub struct ScanConfig {
+    /// Uppercase drive letters to skip during discovery (no colon).
+    pub excluded_drives: Vec<char>,
+}
+
+#[derive(Debug, Default)]
+pub struct ScanResult {
+    pub games: Vec<Game>,
+}
+
+/// Community-verified game list bundled from the Python app's data file
+/// (kept as the single source of truth at src/data/).
+struct VerifiedList {
+    entries: Vec<(String, String)>, // (name_lower, appid)
+}
+
+impl VerifiedList {
+    fn load() -> Self {
+        let raw = include_str!("../../../../../src/data/community_verified_games.json");
+        let mut entries = Vec::new();
+        if let Ok(data) = serde_json::from_str::<Value>(raw) {
+            for g in data
+                .get("games")
+                .and_then(Value::as_array)
+                .unwrap_or(&Vec::new())
+            {
+                let name = g.get("name").and_then(Value::as_str).unwrap_or("");
+                let appid = g.get("appid").and_then(Value::as_str).unwrap_or("");
+                if !name.is_empty() {
+                    entries.push((name.to_lowercase(), appid.to_string()));
+                }
+            }
+        }
+        Self { entries }
+    }
+
+    /// Port of `_is_community_verified`: match by name or by appid.
+    /// (The Python original also checks the (name, appid) pair first, but
+    /// that branch is subsumed by the name-only check.)
+    fn is_verified(&self, name: &str, appid: Option<u32>) -> bool {
+        let name_key = name.to_lowercase();
+        let appid_key = appid.map(|a| a.to_string()).unwrap_or_default();
+        self.entries
+            .iter()
+            .any(|(n, a)| n == &name_key || (!appid_key.is_empty() && a == &appid_key))
+    }
+}
+
+/// Build a Game from a validated game folder + its facts.
+fn build_game(
+    name: String,
+    appid: Option<u32>,
+    path: &Path,
+    platform: Platform,
+    facts: &folder_facts::FolderFacts,
+    verified: &VerifiedList,
+) -> Game {
+    let engine = folder_facts::detect_engine(path, facts);
+    Game {
+        key: GameKey {
+            name_lower: name.to_lowercase(),
+            path_norm: path.to_string_lossy().to_lowercase(),
+        },
+        name,
+        path: path.to_path_buf(),
+        platform,
+        steam_appid: appid,
+        engine,
+        engine_supported: folder_facts::is_engine_supported(engine),
+        anti_cheat: folder_facts::detect_anti_cheat(facts),
+        community_verified: false, // filled by caller (needs final name)
+        optiscaler_installed: folder_facts::detect_optiscaler(path, facts),
+    }
+    .tap_verify(verified)
+}
+
+trait TapVerify {
+    fn tap_verify(self, verified: &VerifiedList) -> Self;
+}
+impl TapVerify for Game {
+    fn tap_verify(mut self, verified: &VerifiedList) -> Self {
+        self.community_verified = verified.is_verified(&self.name, self.steam_appid);
+        self
+    }
+}
+
+/// Scan one Steam library root exactly once per scan pass.
+fn scan_steam_library(
+    library_root: &Path,
+    scanned_roots: &mut HashSet<String>,
+    verified: &VerifiedList,
+    games: &mut Vec<Game>,
+) {
+    let steamapps = library_root.join("steamapps");
+    let common = steamapps.join("common");
+    if !common.is_dir() {
+        return;
+    }
+    let key = common.to_string_lossy().to_lowercase();
+    if !scanned_roots.insert(key) {
+        return;
+    }
+    let manifest_map = steam::build_manifest_map(&steamapps);
+    let Ok(entries) = std::fs::read_dir(&common) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let folder = entry.path();
+        if !folder.is_dir() {
+            continue;
+        }
+        let Some(facts) = folder_facts::collect(&folder) else {
+            continue;
+        };
+        if !folder_facts::is_game_folder(&folder, &facts) {
+            continue;
+        }
+        let folder_name = folder
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let (name, appid) = match manifest_map.get(&folder_name.to_lowercase()) {
+            Some(m) => (m.name.clone(), m.appid),
+            None => (folder_name, None),
+        };
+        games.push(build_game(
+            name,
+            appid,
+            &folder,
+            Platform::Steam,
+            &facts,
+            verified,
+        ));
+    }
+}
+
+/// Scan a root whose child folders are individual games (Epic/GOG style).
+fn scan_children<F>(
+    root: &Path,
+    platform: Platform,
+    verified: &VerifiedList,
+    games: &mut Vec<Game>,
+    name_for: F,
+) where
+    F: Fn(&Path) -> String,
+{
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let folder = entry.path();
+        if !folder.is_dir() {
+            continue;
+        }
+        let Some(facts) = folder_facts::collect(&folder) else {
+            continue;
+        };
+        if !folder_facts::is_game_folder(&folder, &facts) {
+            continue;
+        }
+        let name = name_for(&folder);
+        games.push(build_game(name, None, &folder, platform, &facts, verified));
+    }
+}
+
+fn scan_xbox_root(root: &Path, verified: &VerifiedList, games: &mut Vec<Game>) {
+    let root_name = root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+    let is_xboxgames = root_name == "xboxgames";
+    let is_windowsapps = root_name == "windowsapps";
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let folder = entry.path();
+        if !folder.is_dir() {
+            continue;
+        }
+        let folder_name = folder
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if is_windowsapps && !names::is_appx_game_candidate(&folder_name) {
+            continue; // cheap name filter before walking the package
+        }
+        let Some(facts) = folder_facts::collect(&folder) else {
+            continue;
+        };
+        let name = if is_xboxgames {
+            if !folder_facts::is_game_folder(&folder, &facts) && !xbox::is_xbox_game_folder(&folder)
+            {
+                continue;
+            }
+            names::folder_name_to_title(&folder_name)
+        } else if is_windowsapps {
+            if !folder_facts::is_game_folder(&folder, &facts) {
+                continue;
+            }
+            let parsed = names::title_case(&names::parse_appx_package_name(&folder_name));
+            if parsed.len() < 2 {
+                continue;
+            }
+            parsed
+        } else {
+            if !folder_facts::is_game_folder(&folder, &facts) {
+                continue;
+            }
+            names::folder_name_to_title(&folder_name)
+        };
+        games.push(build_game(
+            name,
+            None,
+            &folder,
+            Platform::Xbox,
+            &facts,
+            verified,
+        ));
+    }
+}
+
+fn scan_heroic(verified: &VerifiedList, games: &mut Vec<Game>) {
+    let mut seen_paths = HashSet::new();
+    for root in heroic::config_roots() {
+        for (title, install_path) in heroic::installed_entries(&root) {
+            let norm = install_path.to_string_lossy().to_lowercase();
+            if seen_paths.contains(&norm) || !install_path.is_dir() {
+                continue;
+            }
+            let Some(facts) = folder_facts::collect(&install_path) else {
+                continue;
+            };
+            if !folder_facts::is_game_folder(&install_path, &facts) {
+                continue;
+            }
+            seen_paths.insert(norm);
+            let name = title.unwrap_or_else(|| {
+                install_path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().replace(['_', '-'], " "))
+                    .unwrap_or_default()
+            });
+            games.push(build_game(
+                name,
+                None,
+                &install_path,
+                Platform::Heroic,
+                &facts,
+                verified,
+            ));
+        }
+    }
+}
+
+/// Epic/GOG name resolution used by both known roots and discovered roots.
+fn epic_name(folder: &Path) -> String {
+    epic::read_game_name(folder).unwrap_or_else(|| {
+        let raw = folder
+            .file_name()
+            .map(|n| n.to_string_lossy().replace(['_', '-'], " "))
+            .unwrap_or_default();
+        names::title_case(&names::split_camel_case(&raw))
+    })
+}
+
+fn gog_name(folder: &Path) -> String {
+    gog::read_game_title(folder).unwrap_or_else(|| {
+        names::folder_name_to_title(
+            &folder
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default(),
+        )
+    })
+}
+
+/// Full scan across all platforms. Port of `GameScanner.scan_games`.
+pub fn scan_all(config: &ScanConfig) -> ScanResult {
+    let verified = VerifiedList::load();
+    let mut games: Vec<Game> = Vec::new();
+    let mut scanned_steam_roots: HashSet<String> = HashSet::new();
+
+    // Steam: install roots + libraryfolders.vdf libraries, each scanned once
+    for library_root in steam::all_library_roots() {
+        scan_steam_library(
+            &library_root,
+            &mut scanned_steam_roots,
+            &verified,
+            &mut games,
+        );
+    }
+
+    // Epic / GOG / Xbox known roots
+    for root in epic::default_roots() {
+        scan_children(&root, Platform::Epic, &verified, &mut games, epic_name);
+    }
+    for root in gog::default_roots() {
+        scan_children(&root, Platform::Gog, &verified, &mut games, gog_name);
+    }
+    for root in xbox::default_roots() {
+        scan_xbox_root(&root, &verified, &mut games);
+    }
+
+    // Heroic store files
+    scan_heroic(&verified, &mut games);
+
+    // Drive discovery for library roots outside the defaults
+    for LibraryRoot { kind, path } in discovery::discover_roots(&config.excluded_drives) {
+        match kind {
+            RootKind::Steam => {
+                // discovered path is the library root itself (contains steamapps)
+                scan_steam_library(&path, &mut scanned_steam_roots, &verified, &mut games);
+            }
+            RootKind::Epic => {
+                scan_children(&path, Platform::Epic, &verified, &mut games, epic_name)
+            }
+            RootKind::Gog => scan_children(&path, Platform::Gog, &verified, &mut games, gog_name),
+            RootKind::Xbox => scan_xbox_root(&path, &verified, &mut games),
+        }
+    }
+
+    // Launcher/redistributable filter, then dedup (same keys as Python)
+    games.retain(|g| !names::is_launcher_entry(&g.name));
+    let mut unique: Vec<Game> = Vec::with_capacity(games.len());
+    let mut seen_path_keys: HashSet<(String, String)> = HashSet::new();
+    let mut seen_name_platform: HashSet<(String, Platform)> = HashSet::new();
+    for game in games {
+        let path_key = (game.key.name_lower.clone(), game.key.path_norm.clone());
+        if seen_path_keys.contains(&path_key) {
+            continue;
+        }
+        let plat_key = (game.key.name_lower.clone(), game.platform);
+        if seen_name_platform.contains(&plat_key) {
+            continue;
+        }
+        seen_path_keys.insert(path_key);
+        seen_name_platform.insert(plat_key);
+        unique.push(game);
+    }
+
+    ScanResult { games: unique }
+}
+
+/// Scan a single, explicitly chosen folder (the "manual path" flow).
+pub fn scan_manual_folder(folder: &Path) -> Option<Game> {
+    let verified = VerifiedList::load();
+    let facts = folder_facts::collect(folder)?;
+    if !folder_facts::is_game_folder(folder, &facts) {
+        return None;
+    }
+    let name = names::folder_name_to_title(
+        &folder
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default(),
+    );
+    Some(build_game(
+        name,
+        None,
+        folder,
+        Platform::Manual,
+        &facts,
+        &verified,
+    ))
+}
+
+/// Extra Steam library roots callers may inject (used by tests).
+pub fn scan_steam_root_for_tests(library_root: &Path) -> Vec<Game> {
+    let verified = VerifiedList::load();
+    let mut games = Vec::new();
+    let mut scanned = HashSet::new();
+    scan_steam_library(library_root, &mut scanned, &verified, &mut games);
+    games
+}
+
+pub type PathList = Vec<PathBuf>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::io::Write;
+
+    fn make_game_dir(base: &Path, name: &str) -> PathBuf {
+        let d = base.join(name);
+        fs::create_dir_all(&d).unwrap();
+        File::create(d.join("game.exe")).unwrap();
+        for i in 0..6 {
+            File::create(d.join(format!("asset{i}.pak"))).unwrap();
+        }
+        d
+    }
+
+    #[test]
+    fn steam_library_scanned_once_with_manifest_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path();
+        let steamapps = lib.join("steamapps");
+        fs::create_dir_all(steamapps.join("common")).unwrap();
+        make_game_dir(&steamapps.join("common"), "TestGame");
+        let mut f = File::create(steamapps.join("appmanifest_111.acf")).unwrap();
+        f.write_all(
+            b"\"AppState\"\n{\n\t\"appid\"\t\t\"111\"\n\t\"name\"\t\t\"Test Game\"\n\t\"installdir\"\t\t\"TestGame\"\n}\n",
+        )
+        .unwrap();
+
+        let verified = VerifiedList::load();
+        let mut games = Vec::new();
+        let mut scanned = HashSet::new();
+        scan_steam_library(lib, &mut scanned, &verified, &mut games);
+        scan_steam_library(lib, &mut scanned, &verified, &mut games); // second scan: no-op
+
+        assert_eq!(games.len(), 1);
+        assert_eq!(games[0].name, "Test Game");
+        assert_eq!(games[0].steam_appid, Some(111));
+        assert_eq!(games[0].platform, Platform::Steam);
+    }
+
+    #[test]
+    fn community_verified_matches() {
+        let verified = VerifiedList::load();
+        assert!(verified.is_verified("Cyberpunk 2077", Some(1091500)));
+        assert!(verified.is_verified("cyberpunk 2077", None)); // name-only
+        assert!(!verified.is_verified("Some Unknown Game", None));
+    }
+
+    #[test]
+    fn manual_folder_scan() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = make_game_dir(tmp.path(), "my_manual-game");
+        let game = scan_manual_folder(&d).expect("valid game folder");
+        assert_eq!(game.name, "My Manual Game");
+        assert_eq!(game.platform, Platform::Manual);
+    }
+}

--- a/rust/crates/opticore/src/scan/names.rs
+++ b/rust/crates/opticore/src/scan/names.rs
@@ -1,0 +1,251 @@
+//! Name heuristics ported from the Python scanner (game_scanner.py):
+//! CamelCase splitting, WindowsApps (Appx) package-name parsing, and the
+//! launcher/non-game keyword filters.
+
+/// Split CamelCase/PascalCase and letter↔digit boundaries into words.
+/// Port of `GameScanner._split_camel_case`.
+pub fn split_camel_case(name: &str) -> String {
+    let chars: Vec<char> = name.chars().collect();
+    let mut out = String::with_capacity(name.len() + 8);
+    for (i, &c) in chars.iter().enumerate() {
+        if i > 0 {
+            let prev = chars[i - 1];
+            let boundary = (prev.is_lowercase() && c.is_uppercase())
+                || (prev.is_alphabetic() && c.is_ascii_digit())
+                || (prev.is_ascii_digit() && c.is_alphabetic());
+            if boundary {
+                out.push(' ');
+            }
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Title-case each word (Python's `str.title()` for our ASCII-ish names).
+pub fn title_case(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut at_word_start = true;
+    for c in s.chars() {
+        if c.is_alphanumeric() {
+            if at_word_start {
+                out.extend(c.to_uppercase());
+            } else {
+                out.extend(c.to_lowercase());
+            }
+            at_word_start = false;
+        } else {
+            out.push(c);
+            at_word_start = true;
+        }
+    }
+    out
+}
+
+/// Replace underscores/hyphens with spaces and title-case — the folder-name
+/// fallback used across the Python scanners.
+pub fn folder_name_to_title(folder_name: &str) -> String {
+    title_case(&folder_name.replace(['_', '-'], " "))
+}
+
+/// Extract a readable game name from a WindowsApps folder
+/// (`Publisher.AppName_Version_Arch_Hash`). Port of `_parse_appx_package_name`.
+pub fn parse_appx_package_name(folder_name: &str) -> String {
+    // Strip everything from the first "_<digits>.<digit>..." (version suffix)
+    let mut base = folder_name;
+    let bytes: Vec<char> = folder_name.chars().collect();
+    for (i, &c) in bytes.iter().enumerate() {
+        if c == '_' {
+            // does a version number follow? (digits then '.')
+            let rest: String = bytes[i + 1..].iter().collect();
+            let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if !digits.is_empty() && rest[digits.len()..].starts_with('.') {
+                base = &folder_name[..folder_name
+                    .char_indices()
+                    .nth(i)
+                    .map(|(b, _)| b)
+                    .unwrap_or(folder_name.len())];
+                break;
+            }
+        }
+    }
+    // Take the AppName after the last dot (drop the publisher)
+    let base = base.rsplit('.').next().unwrap_or(base);
+    split_camel_case(base).trim().to_string()
+}
+
+/// Known non-game keyword fragments in Appx package names.
+/// Port of `_APPX_NON_GAME_KEYWORDS`.
+const APPX_NON_GAME_KEYWORDS: &[&str] = &[
+    "vclibs",
+    "runtime",
+    "framework",
+    "xaml",
+    "webpimage",
+    "hevcvideo",
+    "heifimage",
+    "mpeg2video",
+    "vp9video",
+    "webmedia",
+    "codec",
+    "videoextension",
+    "imageextension",
+    "storepurchase",
+    "storeengagement",
+    "store.engagement",
+    "directxruntime",
+    "net.native",
+    "appruntime",
+    "winappruntime",
+    "windowsappruntime",
+    "gamingservices",
+    "xboxgamingoverlay",
+    "gamingapp",
+    "xboxidentityprovider",
+    "xboxdevices",
+    "xbox.tcui",
+    "bingwallpaper",
+    "getstarted",
+    "gethelp",
+    "startexperiencesapp",
+    "commandpalette",
+    "webexperience",
+    "crossdevice",
+    "sechealthui",
+    "screensketch",
+    "widgetsplatform",
+    "foundrylocal",
+    "applicationcompatibility",
+    "avcencoder",
+    "windowsstore",
+    "storepurchaseapp",
+    "yourphone",
+    "windowsterminal",
+    "windowsnotepad",
+    "windowscalculator",
+    "windowscamera",
+    "windowsphotos",
+    "zunemusic",
+    "microsoftmahjong",
+    "candycrush",
+    "linkedinfor",
+    "whatsappdesktop",
+    "clipchamp",
+    "dolbyaccess",
+    "dtssound",
+    "armourycrate",
+    "lgmonitor",
+    "realtekaudio",
+    "tobiieyetracking",
+    "speedtest",
+    "hdrcalibration",
+    "camostudio",
+    "icloud",
+    "itunes",
+    "applemusic",
+    "appletv",
+    "primevideo",
+    "vidstok",
+    "gameassist",
+    "paint",
+    "photos",
+    "minecraftuwp",
+    "minecraftlauncher",
+    "facebook",
+    "netflix",
+    "desktopappinstaller",
+    "languageexperience",
+    "solitairecollection",
+    "onedrivesync",
+    "powertoys",
+    "microsoftedge",
+    "preordercontent",
+    "cloudspremium",
+    "anthropic",
+    "claude_",
+];
+
+/// True if the WindowsApps folder could be a game. Port of `_is_appx_game_candidate`.
+pub fn is_appx_game_candidate(folder_name: &str) -> bool {
+    let lower = folder_name.to_lowercase();
+    if !folder_name.contains('_') {
+        return false;
+    }
+    // Skip packages whose AppName part looks like a hex identifier
+    let name_part = lower.split('_').next().unwrap_or("");
+    let app_part = name_part.rsplit('.').next().unwrap_or("");
+    let squeezed: String = app_part.chars().filter(|c| *c != ' ').collect();
+    if squeezed.len() >= 6 && squeezed.chars().all(|c| c.is_ascii_hexdigit()) {
+        return false;
+    }
+    !APPX_NON_GAME_KEYWORDS.iter().any(|kw| lower.contains(kw))
+}
+
+/// Launcher/redistributable entries filtered out of scan results.
+/// Port of the `_launcher_keywords` filter in `scan_games`.
+const LAUNCHER_KEYWORDS: &[&str] = &[
+    "launcher",
+    "redistributable",
+    "directx",
+    "vcredist",
+    "dotnet",
+    "steamworks common",
+];
+
+pub fn is_launcher_entry(game_name: &str) -> bool {
+    let lower = game_name.to_lowercase();
+    LAUNCHER_KEYWORDS.iter().any(|kw| lower.contains(kw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_camel_case() {
+        assert_eq!(split_camel_case("HaloInfinite"), "Halo Infinite");
+        assert_eq!(split_camel_case("Game2Exe"), "Game 2 Exe");
+        assert_eq!(split_camel_case("already split"), "already split");
+    }
+
+    #[test]
+    fn parses_appx_names() {
+        assert_eq!(
+            parse_appx_package_name("Hoodedhorse.ManorLords_1.5.1.0_x64__abc123"),
+            "Manor Lords"
+        );
+        assert_eq!(
+            parse_appx_package_name("Microsoft.HaloInfinite_6.10021.18539.0_x64__8wekyb3d8bbwe"),
+            "Halo Infinite"
+        );
+    }
+
+    #[test]
+    fn appx_candidate_filter() {
+        assert!(is_appx_game_candidate(
+            "Hoodedhorse.ManorLords_1.5.1.0_x64__abc"
+        ));
+        assert!(!is_appx_game_candidate("Deleted")); // no underscore
+        assert!(!is_appx_game_candidate(
+            "Microsoft.VCLibs.140.00_14.0.33519.0_x64__8wekyb3d8bbwe"
+        ));
+        assert!(!is_appx_game_candidate(
+            "1Ed5Aea5.4160926B82Db_1.0.0.0_x64__xyz"
+        )); // hex id
+    }
+
+    #[test]
+    fn launcher_filter() {
+        assert!(is_launcher_entry("Epic Games Launcher"));
+        assert!(is_launcher_entry("DirectX Redist"));
+        assert!(!is_launcher_entry("Death Stranding"));
+    }
+
+    #[test]
+    fn folder_name_titles() {
+        assert_eq!(
+            folder_name_to_title("dead_space-remake"),
+            "Dead Space Remake"
+        );
+    }
+}

--- a/rust/crates/opticore/src/scan/steam.rs
+++ b/rust/crates/opticore/src/scan/steam.rs
@@ -1,0 +1,220 @@
+//! Steam library scanning: appmanifest ACF parsing, libraryfolders.vdf,
+//! and the once-per-library common/ folder walk.
+//!
+//! ACF/VDF values are extracted with a small line-based parser (the Python
+//! app does the same with regexes) — it tolerates both the classic VDF
+//! format and the newer JSON-styled libraryfolders.vdf.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Extract the first quoted value following a quoted key, e.g. `"name" "X"`.
+/// Works line-by-line; tolerates `"key": "value"` (JSON-ish) too.
+fn quoted_field(content: &str, key: &str) -> Option<String> {
+    let needle = format!("\"{key}\"");
+    for line in content.lines() {
+        if let Some(pos) = line.find(&needle) {
+            let rest = &line[pos + needle.len()..];
+            if let Some(value) = next_quoted(rest) {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+/// All quoted values following any occurrence of the quoted key.
+fn quoted_fields(content: &str, key: &str) -> Vec<String> {
+    let needle = format!("\"{key}\"");
+    let mut out = Vec::new();
+    for line in content.lines() {
+        if let Some(pos) = line.find(&needle) {
+            if let Some(value) = next_quoted(&line[pos + needle.len()..]) {
+                out.push(value);
+            }
+        }
+    }
+    out
+}
+
+/// First quoted string in `s`, with VDF backslash-escapes collapsed.
+fn next_quoted(s: &str) -> Option<String> {
+    let start = s.find('"')? + 1;
+    let rest = &s[start..];
+    let mut out = String::new();
+    let mut chars = rest.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '"' => return Some(out),
+            '\\' => {
+                if let Some(escaped) = chars.next() {
+                    out.push(escaped);
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    None
+}
+
+/// One parsed appmanifest entry.
+#[derive(Debug, Clone)]
+pub struct ManifestEntry {
+    pub name: String,
+    pub appid: Option<u32>,
+}
+
+/// Parse every `appmanifest_*.acf` once: installdir (lowercased) → entry.
+/// Port of `_build_steam_manifest_map`.
+pub fn build_manifest_map(steamapps: &Path) -> HashMap<String, ManifestEntry> {
+    let mut map = HashMap::new();
+    let Ok(entries) = fs::read_dir(steamapps) else {
+        return map;
+    };
+    for entry in entries.flatten() {
+        let fname = entry.file_name().to_string_lossy().to_string();
+        if !fname.starts_with("appmanifest_") || !fname.ends_with(".acf") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let (Some(installdir), Some(name)) = (
+            quoted_field(&content, "installdir"),
+            quoted_field(&content, "name"),
+        ) else {
+            continue;
+        };
+        let appid = quoted_field(&content, "appid").and_then(|a| a.parse().ok());
+        map.insert(installdir.to_lowercase(), ManifestEntry { name, appid });
+    }
+    map
+}
+
+/// Steam library roots listed in a `libraryfolders.vdf` (both formats).
+pub fn library_roots_from_vdf(vdf_path: &Path) -> Vec<PathBuf> {
+    let Ok(content) = fs::read_to_string(vdf_path) else {
+        return Vec::new();
+    };
+    quoted_fields(&content, "path")
+        .into_iter()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+        .collect()
+}
+
+/// Default + registry Steam install roots. Port of `_find_steam_paths`.
+pub fn steam_install_roots() -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    #[cfg(windows)]
+    {
+        for (hive, key) in [
+            (
+                windows_registry::LOCAL_MACHINE,
+                r"SOFTWARE\Wow6432Node\Valve\Steam",
+            ),
+            (windows_registry::LOCAL_MACHINE, r"SOFTWARE\Valve\Steam"),
+            (windows_registry::CURRENT_USER, r"SOFTWARE\Valve\Steam"),
+        ] {
+            if let Ok(k) = hive.open(key) {
+                for value_name in ["InstallPath", "SteamPath"] {
+                    if let Ok(path) = k.get_string(value_name) {
+                        candidates.push(PathBuf::from(path));
+                    }
+                }
+            }
+        }
+    }
+    candidates.push(PathBuf::from(r"C:\Program Files (x86)\Steam"));
+    candidates.push(PathBuf::from(r"C:\Program Files\Steam"));
+    if let Some(home) = std::env::var_os("USERPROFILE") {
+        candidates.push(PathBuf::from(home).join(r"AppData\Local\Steam"));
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    candidates
+        .into_iter()
+        .filter(|p| p.is_dir())
+        .filter(|p| seen.insert(p.to_string_lossy().to_lowercase()))
+        .collect()
+}
+
+/// All Steam library roots: install roots plus everything their
+/// libraryfolders.vdf files reference.
+pub fn all_library_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for install_root in steam_install_roots() {
+        if seen.insert(install_root.to_string_lossy().to_lowercase()) {
+            roots.push(install_root.clone());
+        }
+        let vdf = install_root.join("steamapps").join("libraryfolders.vdf");
+        if vdf.exists() {
+            for lib in library_roots_from_vdf(&vdf) {
+                if seen.insert(lib.to_string_lossy().to_lowercase()) {
+                    roots.push(lib);
+                }
+            }
+        }
+    }
+    roots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    const ACF: &str = r#""AppState"
+{
+	"appid"		"1091500"
+	"name"		"Cyberpunk 2077"
+	"installdir"		"Cyberpunk 2077"
+}
+"#;
+
+    #[test]
+    fn parses_acf_fields() {
+        assert_eq!(quoted_field(ACF, "name").as_deref(), Some("Cyberpunk 2077"));
+        assert_eq!(quoted_field(ACF, "appid").as_deref(), Some("1091500"));
+        assert_eq!(
+            quoted_field(ACF, "installdir").as_deref(),
+            Some("Cyberpunk 2077")
+        );
+    }
+
+    #[test]
+    fn builds_manifest_map() {
+        let tmp = tempfile::tempdir().unwrap();
+        let steamapps = tmp.path().join("steamapps");
+        std::fs::create_dir_all(&steamapps).unwrap();
+        let mut f = File::create(steamapps.join("appmanifest_1091500.acf")).unwrap();
+        f.write_all(ACF.as_bytes()).unwrap();
+
+        let map = build_manifest_map(&steamapps);
+        let entry = map.get("cyberpunk 2077").expect("entry present");
+        assert_eq!(entry.name, "Cyberpunk 2077");
+        assert_eq!(entry.appid, Some(1091500));
+    }
+
+    #[test]
+    fn parses_libraryfolders_both_formats() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("OtherLib");
+        std::fs::create_dir_all(&lib).unwrap();
+        let escaped = lib.to_string_lossy().replace('\\', "\\\\");
+
+        let classic = format!(
+            "\"libraryfolders\"\n{{\n\t\"0\"\n\t{{\n\t\t\"path\"\t\t\"{escaped}\"\n\t}}\n}}\n"
+        );
+        let vdf_path = tmp.path().join("libraryfolders.vdf");
+        std::fs::write(&vdf_path, classic).unwrap();
+        assert_eq!(library_roots_from_vdf(&vdf_path), vec![lib.clone()]);
+
+        let json_style = format!("{{\"libraryfolders\": {{\"0\": {{\"path\": \"{escaped}\"}}}}}}");
+        std::fs::write(&vdf_path, json_style).unwrap();
+        assert_eq!(library_roots_from_vdf(&vdf_path), vec![lib]);
+    }
+}

--- a/rust/crates/opticore/src/scan/xbox.rs
+++ b/rust/crates/opticore/src/scan/xbox.rs
@@ -1,0 +1,72 @@
+//! Xbox / Game Pass helpers: XboxGames packaging heuristics and roots.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Known Xbox roots (XboxGames on any fixed drive is added by discovery).
+pub fn default_roots() -> Vec<PathBuf> {
+    [r"C:\XboxGames", r"C:\Program Files\WindowsApps"]
+        .iter()
+        .map(PathBuf::from)
+        .filter(|p| p.is_dir())
+        .collect()
+}
+
+/// Xbox streaming/packaging file extensions identifying a Game Pass title.
+const XBOX_GAME_EXTENSIONS: &[&str] = &["xsp", "smd", "xct", "xvi"];
+
+/// True if the folder looks like an Xbox Game Pass title (packaging files,
+/// gamelaunchhelper.exe, or a Content subfolder). Port of `_is_xbox_game_folder`.
+pub fn is_xbox_game_folder(game_folder: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(game_folder) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_lowercase();
+        if let Some(ext) = Path::new(&name).extension().and_then(|e| e.to_str()) {
+            if XBOX_GAME_EXTENSIONS.contains(&ext) {
+                return true;
+            }
+        }
+        if name == "gamelaunchhelper.exe" {
+            return true;
+        }
+        if name == "content" && entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+
+    #[test]
+    fn detects_packaging_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("XGame");
+        fs::create_dir_all(&game).unwrap();
+        File::create(game.join("data.xsp")).unwrap();
+        assert!(is_xbox_game_folder(&game));
+    }
+
+    #[test]
+    fn detects_gamelaunchhelper() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("XGame2");
+        fs::create_dir_all(&game).unwrap();
+        File::create(game.join("GameLaunchHelper.exe")).unwrap();
+        assert!(is_xbox_game_folder(&game));
+    }
+
+    #[test]
+    fn plain_folder_is_not_xbox() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("Plain");
+        fs::create_dir_all(&game).unwrap();
+        File::create(game.join("app.exe")).unwrap();
+        assert!(!is_xbox_game_folder(&game));
+    }
+}


### PR DESCRIPTION
Second milestone of the Rust rewrite: the complete scanning pipeline in `opticore::scan`, verified game-for-game against the Python app.

## Parity verification (the M1 gate)

`cargo run --release -p opticore --example scan_cli` on the dev machine vs the Python v0.5.2 scanner:

| | Python v0.5.2 | Rust M1 |
|---|---|---|
| Games found | 28 (Steam 20, Epic 1, Xbox 7) | **28 — identical platform\|name list** |
| Scan time | 0.77 s | **0.19 s** |

The comparison earned its keep immediately: the first run found 24/28 — a walker depth off-by-one vs Python made deep Unreal layouts (exe in `Game/Binaries/Win64/`) invisible. Fixed and re-verified.

## What''s ported

- **folder_facts** — one bounded directory walk per game folder feeding all four detectors (game-folder, engine, anti-cheat, OptiScaler-installed), the structural fix from the Python v0.5.2 audit carried over.
- **steam** — registry + default install roots, `libraryfolders.vdf` (both formats), one manifest map per library, each library scanned exactly once. Uses a small line-based ACF/VDF parser instead of the planned `keyvalues-parser` crate (same semantics as Python''s regex approach, one less dependency) — flagged as a plan deviation.
- **heroic** — all four store backends, direct port of the v0.5.1 fix.
- **epic / gog / xbox** — metadata titles (.egstore/.mancfg, goggame-*.info), XboxGames packaging heuristics, WindowsApps Appx name parsing + non-game keyword filter.
- **discovery** — native fixed-drive probing; the PowerShell discovery pipeline and its 24h cache have no Rust counterpart because they''re unnecessary.
- **names** — CamelCase splitting, Appx parsing, launcher filtering; **mod.rs** — orchestrator with Python-identical dedup keys, `scan_manual_folder`, embedded community-verified list.

## Testing

28 unit tests (fixture-driven, modeled on the Python test suites): ACF/VDF both formats, all four Heroic stores, detector parity from one FolderFacts walk, library-scanned-once, Appx/name-heuristic tables, manual-folder flow. clippy `-D warnings` clean — including a real catch (a redundant boolean in the verified-list check, simplified with a note).

Next: **M2 — GUI shell + virtualized games grid + image pipeline.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)