### PR TITLE
Rust rewrite M2: GUI shell, virtualized card grid, artwork pipeline

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -129,6 +129,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +192,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -389,7 +410,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -456,6 +477,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +510,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -730,12 +763,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -748,6 +790,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -915,6 +963,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,10 +1098,23 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -1292,6 +1369,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,7 +1485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -1407,6 +1501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
@@ -1419,7 +1514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -1431,7 +1526,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1443,7 +1538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1478,7 +1573,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -1490,7 +1585,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -1509,7 +1604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -1543,7 +1638,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -1556,7 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1568,7 +1663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -1591,7 +1686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -1611,7 +1706,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -1623,7 +1718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -1636,15 +1731,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "opticore"
 version = "2026.7.0-alpha.1"
 dependencies = [
  "hex",
+ "image",
  "serde",
  "serde_json",
  "sevenz-rust2",
  "sha2",
  "tempfile",
+ "ureq",
  "windows-registry",
 ]
 
@@ -1653,7 +1793,9 @@ name = "optiscaler-gui"
 version = "2026.7.0-alpha.1"
 dependencies = [
  "eframe",
+ "image",
  "opticore",
+ "rfd",
  "wgpu",
 ]
 
@@ -1706,6 +1848,15 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1927,6 +2078,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,6 +2170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2189,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2372,6 +2585,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "der",
+ "flate2",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,10 +2627,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2616,6 +2871,15 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3020,7 +3284,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.13.0",
- "block2",
+ "block2 0.5.1",
  "calloop 0.13.0",
  "cfg_aliases",
  "concurrent-queue",
@@ -3171,6 +3435,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/rust/crates/opticore/Cargo.toml
+++ b/rust/crates/opticore/Cargo.toml
@@ -11,6 +11,8 @@ sevenz-rust2 = "0.21"
 sha2 = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+ureq = { version = "3", default-features = false, features = ["native-tls", "gzip"] }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-registry = "0.6"

--- a/rust/crates/opticore/src/appids.rs
+++ b/rust/crates/opticore/src/appids.rs
@@ -1,0 +1,360 @@
+//! Steam AppID lookup: local manifests → SteamSpy catalogue (7-day disk
+//! cache) with the Python matching ladder (exact → normalized →
+//! edition-suffix stripping → token-subset via token index).
+//!
+//! Deviation from the Python app: the final difflib fuzzy-match step is not
+//! ported (rare last resort; revisit if parity testing shows misses).
+
+use crate::scan::steam;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, SystemTime};
+
+const CACHE_FILE: &str = "steam_app_list.json";
+const CACHE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+const STEAMSPY_PAGE_CAP: u32 = 50;
+
+/// Platform/edition qualifiers stripped progressively from names.
+/// Port of `_NAME_STRIP_SUFFIXES` (suffix-anchored, case-insensitive).
+const NAME_STRIP_SUFFIXES: &[&str] = &[
+    "for windows",
+    "for pc",
+    "for xbox",
+    "game of the year edition",
+    "goty edition",
+    "complete edition",
+    "definitive edition",
+    "enhanced edition",
+    "remastered",
+    "standard edition",
+    "gold edition",
+    "deluxe edition",
+    "ultimate edition",
+    "windows edition",
+    "pc edition",
+    "microsoft store",
+];
+
+/// `re.sub(r'[^a-z0-9\s]', ' ', s)` + whitespace collapse, on a lowercase input.
+fn normalize(s: &str) -> String {
+    let replaced: String = s
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c.is_whitespace() {
+                c
+            } else {
+                ' '
+            }
+        })
+        .collect();
+    replaced.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_suffix_once(name: &str) -> Option<String> {
+    let trimmed = name.trim_end();
+    for suffix in NAME_STRIP_SUFFIXES {
+        if let Some(stripped) = trimmed.strip_suffix(suffix) {
+            let stripped = stripped.trim_end();
+            // must be preceded by whitespace (Python: `\s+` before the suffix)
+            if !stripped.is_empty() && stripped.len() < trimmed.len() {
+                return Some(stripped.to_string());
+            }
+        }
+    }
+    None
+}
+
+struct Index {
+    /// name (lowercase) → appid
+    by_name: HashMap<String, u32>,
+    /// normalized name → appid
+    by_normalized: HashMap<String, u32>,
+    /// token → set of name keys containing it
+    token_index: HashMap<String, HashSet<String>>,
+    /// name key → token count (for smallest-name preference)
+    token_counts: HashMap<String, usize>,
+}
+
+impl Index {
+    fn build(apps: &HashMap<String, u32>) -> Self {
+        let mut by_normalized = HashMap::new();
+        let mut token_index: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut token_counts = HashMap::new();
+        for (name, &appid) in apps {
+            let norm = normalize(name);
+            by_normalized.entry(norm.clone()).or_insert(appid);
+            let tokens: HashSet<&str> = norm.split_whitespace().collect();
+            if tokens.is_empty() {
+                continue;
+            }
+            token_counts.insert(name.clone(), tokens.len());
+            for tok in tokens {
+                token_index
+                    .entry(tok.to_string())
+                    .or_default()
+                    .insert(name.clone());
+            }
+        }
+        Self {
+            by_name: apps.clone(),
+            by_normalized,
+            token_index,
+            token_counts,
+        }
+    }
+
+    fn lookup(&self, game_name: &str) -> Option<u32> {
+        let base = game_name.to_lowercase().trim().to_string();
+        if base.is_empty() {
+            return None;
+        }
+        // Progressive edition-suffix stripping
+        let mut variants = vec![base.clone()];
+        let mut current = base;
+        while let Some(next) = strip_suffix_once(&current) {
+            variants.push(next.clone());
+            current = next;
+        }
+
+        for candidate in &variants {
+            if let Some(&appid) = self.by_name.get(candidate) {
+                return Some(appid);
+            }
+            let norm = normalize(candidate);
+            if let Some(&appid) = self.by_normalized.get(&norm) {
+                return Some(appid);
+            }
+            // Token-subset: all query tokens present; prefer fewest-token name
+            let tokens: Vec<&str> = norm.split_whitespace().collect();
+            if tokens.is_empty() {
+                continue;
+            }
+            let mut candidates: Option<HashSet<&String>> = None;
+            for tok in &tokens {
+                match self.token_index.get(*tok) {
+                    Some(keys) => {
+                        let keys: HashSet<&String> = keys.iter().collect();
+                        candidates = Some(match candidates {
+                            None => keys,
+                            Some(prev) => prev.intersection(&keys).copied().collect(),
+                        });
+                    }
+                    None => {
+                        candidates = Some(HashSet::new());
+                        break;
+                    }
+                }
+            }
+            let best = candidates
+                .unwrap_or_default()
+                .into_iter()
+                .min_by_key(|key| self.token_counts.get(*key).copied().unwrap_or(usize::MAX));
+            if let Some(key) = best {
+                if let Some(&appid) = self.by_name.get(key) {
+                    return Some(appid);
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Thread-safe AppID resolver with a per-name memo cache.
+pub struct AppIdResolver {
+    cache_dir: PathBuf,
+    index: RwLock<Index>,
+    memo: Mutex<HashMap<String, Option<u32>>>,
+}
+
+impl AppIdResolver {
+    /// Build instantly from installed-game manifests (plus the disk cache if
+    /// fresh). `cache_dir` is the game_images dir (Python keeps
+    /// steam_app_list.json there — layout kept compatible).
+    pub fn new(cache_dir: &Path) -> Self {
+        let mut apps = load_disk_cache(cache_dir).unwrap_or_default();
+        if apps.is_empty() {
+            apps = local_manifest_apps();
+        }
+        Self {
+            cache_dir: cache_dir.to_path_buf(),
+            index: RwLock::new(Index::build(&apps)),
+            memo: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn lookup(&self, game_name: &str) -> Option<u32> {
+        let key = game_name.to_lowercase();
+        if let Some(hit) = self.memo.lock().unwrap().get(&key) {
+            return *hit;
+        }
+        let result = self.index.read().unwrap().lookup(game_name);
+        self.memo.lock().unwrap().insert(key, result);
+        result
+    }
+
+    /// Download the SteamSpy catalogue (skipped when the disk cache is fresh)
+    /// and swap in the enlarged index. Call from a background thread; returns
+    /// true if the index changed.
+    pub fn load_steamspy_catalogue(&self) -> bool {
+        if disk_cache_is_fresh(&self.cache_dir) {
+            return false;
+        }
+        let mut apps = local_manifest_apps();
+        let agent = crate::images::http_agent();
+        for page in 0..STEAMSPY_PAGE_CAP {
+            let url = format!("https://steamspy.com/api.php?request=all&page={page}");
+            let Ok(mut resp) = agent.get(&url).call() else {
+                break;
+            };
+            let Ok(body) = resp.body_mut().read_to_string() else {
+                break;
+            };
+            let Ok(Value::Object(data)) = serde_json::from_str::<Value>(&body) else {
+                break;
+            };
+            if data.is_empty() {
+                break;
+            }
+            for (appid_str, info) in &data {
+                let name = info.get("name").and_then(Value::as_str).unwrap_or("");
+                if name.len() < 2 {
+                    continue;
+                }
+                let lower = name.to_lowercase();
+                if ["dlc", "demo", "beta", "test"]
+                    .iter()
+                    .any(|kw| lower == *kw || lower.starts_with(&format!("{kw} ")))
+                {
+                    continue;
+                }
+                if let Ok(appid) = appid_str.parse::<u32>() {
+                    apps.insert(lower, appid);
+                }
+            }
+            std::thread::sleep(Duration::from_millis(500)); // be polite to the API
+        }
+        if apps.is_empty() {
+            return false;
+        }
+        save_disk_cache(&self.cache_dir, &apps);
+        *self.index.write().unwrap() = Index::build(&apps);
+        self.memo.lock().unwrap().clear();
+        true
+    }
+}
+
+fn local_manifest_apps() -> HashMap<String, u32> {
+    let mut apps = HashMap::new();
+    for library_root in steam::all_library_roots() {
+        let steamapps = library_root.join("steamapps");
+        for entry in steam::build_manifest_map(&steamapps).into_values() {
+            if let Some(appid) = entry.appid {
+                apps.insert(entry.name.to_lowercase(), appid);
+            }
+        }
+    }
+    apps
+}
+
+fn disk_cache_is_fresh(cache_dir: &Path) -> bool {
+    let path = cache_dir.join(CACHE_FILE);
+    path.metadata()
+        .and_then(|m| m.modified())
+        .map(|modified| {
+            SystemTime::now()
+                .duration_since(modified)
+                .unwrap_or(Duration::MAX)
+                < CACHE_MAX_AGE
+        })
+        .unwrap_or(false)
+}
+
+fn load_disk_cache(cache_dir: &Path) -> Option<HashMap<String, u32>> {
+    if !disk_cache_is_fresh(cache_dir) {
+        return None;
+    }
+    let content = std::fs::read_to_string(cache_dir.join(CACHE_FILE)).ok()?;
+    let raw: HashMap<String, Value> = serde_json::from_str(&content).ok()?;
+    // Python stores appids as strings; accept numbers too
+    Some(
+        raw.into_iter()
+            .filter_map(|(name, v)| {
+                let appid = match &v {
+                    Value::String(s) => s.parse().ok(),
+                    Value::Number(n) => n.as_u64().map(|n| n as u32),
+                    _ => None,
+                }?;
+                Some((name, appid))
+            })
+            .collect(),
+    )
+}
+
+fn save_disk_cache(cache_dir: &Path, apps: &HashMap<String, u32>) {
+    let _ = std::fs::create_dir_all(cache_dir);
+    // Store appids as strings for byte-compat with the Python cache format
+    let as_strings: HashMap<&String, String> =
+        apps.iter().map(|(k, v)| (k, v.to_string())).collect();
+    if let Ok(json) = serde_json::to_string(&as_strings) {
+        let _ = std::fs::write(cache_dir.join(CACHE_FILE), json);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn index_of(entries: &[(&str, u32)]) -> Index {
+        let apps: HashMap<String, u32> = entries.iter().map(|(n, a)| (n.to_string(), *a)).collect();
+        Index::build(&apps)
+    }
+
+    #[test]
+    fn exact_and_normalized_matches() {
+        let idx = index_of(&[
+            ("cyberpunk 2077", 1091500),
+            ("the witcher 3: wild hunt", 292030),
+        ]);
+        assert_eq!(idx.lookup("Cyberpunk 2077"), Some(1091500));
+        assert_eq!(idx.lookup("The Witcher 3 Wild Hunt"), Some(292030)); // punctuation-free
+    }
+
+    #[test]
+    fn edition_suffix_stripping() {
+        let idx = index_of(&[("skyrim", 72850)]);
+        assert_eq!(idx.lookup("Skyrim Special Edition"), None); // "special edition" not in strip list
+        assert_eq!(idx.lookup("Skyrim Ultimate Edition"), Some(72850));
+        assert_eq!(idx.lookup("Skyrim for Windows"), Some(72850));
+    }
+
+    #[test]
+    fn token_subset_prefers_smallest() {
+        let idx = index_of(&[
+            ("halo infinite", 1240440),
+            ("halo infinite multiplayer test build", 999),
+        ]);
+        assert_eq!(idx.lookup("Halo Infinite"), Some(1240440));
+        // subset match: query tokens all appear in the longer name too,
+        // but the fewest-token entry wins
+        assert_eq!(idx.lookup("halo: infinite!"), Some(1240440));
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let idx = index_of(&[("stellaris", 281990)]);
+        assert_eq!(idx.lookup("Definitely Not A Game"), None);
+    }
+
+    #[test]
+    fn disk_cache_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut apps = HashMap::new();
+        apps.insert("raft".to_string(), 648800u32);
+        save_disk_cache(tmp.path(), &apps);
+        let loaded = load_disk_cache(tmp.path()).unwrap();
+        assert_eq!(loaded.get("raft"), Some(&648800));
+    }
+}

--- a/rust/crates/opticore/src/images.rs
+++ b/rust/crates/opticore/src/images.rs
@@ -1,0 +1,171 @@
+//! Game artwork fetching with the Python-compatible disk cache layout
+//! (`cache/game_images/appid_<id>.jpg`, name-keyed legacy stems, existing
+//! caches carry over between the apps).
+//!
+//! Sources, in order: Steam CDN header.jpg → Steam Store API
+//! (header_image / capsule_image). Downloads are resized to max 300×450 and
+//! saved as JPEG q85, matching the Python pipeline.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const MAX_SIZE: (u32, u32) = (300, 450);
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(10);
+const CACHE_EXTENSIONS: &[&str] = &["jpg", "png", "jpeg", "webp"];
+
+pub struct ImageCache {
+    cache_dir: PathBuf,
+}
+
+impl ImageCache {
+    pub fn new(cache_dir: &Path) -> Self {
+        let _ = std::fs::create_dir_all(cache_dir);
+        Self {
+            cache_dir: cache_dir.to_path_buf(),
+        }
+    }
+
+    /// Sanitize a game name the way Python does for legacy name-keyed files.
+    fn safe_name(game_name: &str) -> String {
+        game_name
+            .chars()
+            .map(|c| match c {
+                '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' => '_',
+                other => other,
+            })
+            .collect()
+    }
+
+    /// Cached image path if one exists (appid stem preferred, then name stem).
+    pub fn cached_path(&self, game_name: &str, appid: Option<u32>) -> Option<PathBuf> {
+        let mut stems = Vec::new();
+        if let Some(appid) = appid {
+            stems.push(format!("appid_{appid}"));
+        }
+        stems.push(Self::safe_name(game_name));
+        for stem in stems {
+            for ext in CACHE_EXTENSIONS {
+                let candidate = self.cache_dir.join(format!("{stem}.{ext}"));
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+        None
+    }
+
+    /// Fetch (or return cached) artwork for a game. Blocking — run on a
+    /// worker thread. Returns None when no appid or all sources fail.
+    pub fn fetch(&self, game_name: &str, appid: Option<u32>) -> Option<PathBuf> {
+        if let Some(cached) = self.cached_path(game_name, appid) {
+            return Some(cached);
+        }
+        let appid = appid?;
+
+        // Primary: Steam CDN header
+        let cdn_url = format!("https://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg");
+        if let Some(path) = self.download_and_cache(&cdn_url, appid) {
+            return Some(path);
+        }
+
+        // Fallback: Store API for the actual hosted image URL
+        let store_url =
+            format!("https://store.steampowered.com/api/appdetails?appids={appid}&filters=basic");
+        let body = http_get(&store_url)?;
+        let data: serde_json::Value = serde_json::from_slice(&body).ok()?;
+        let app_info = data.get(appid.to_string())?;
+        if app_info.get("success") != Some(&serde_json::Value::Bool(true)) {
+            return None;
+        }
+        for key in ["header_image", "capsule_image"] {
+            if let Some(url) = app_info
+                .get("data")
+                .and_then(|d| d.get(key))
+                .and_then(serde_json::Value::as_str)
+            {
+                if let Some(path) = self.download_and_cache(url, appid) {
+                    return Some(path);
+                }
+            }
+        }
+        None
+    }
+
+    fn download_and_cache(&self, url: &str, appid: u32) -> Option<PathBuf> {
+        let bytes = http_get(url)?;
+        let img = image::load_from_memory(&bytes).ok()?;
+        let img = img.thumbnail(MAX_SIZE.0, MAX_SIZE.1);
+        let rgb = image::DynamicImage::ImageRgb8(img.to_rgb8());
+        let out_path = self.cache_dir.join(format!("appid_{appid}.jpg"));
+        let mut out = std::fs::File::create(&out_path).ok()?;
+        let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, 85);
+        rgb.write_with_encoder(encoder).ok()?;
+        Some(out_path)
+    }
+}
+
+/// Shared HTTP agent. ureq 3 defaults to the Rustls provider even when built
+/// with the native-tls feature — the provider must be selected explicitly or
+/// every https call panics at runtime.
+pub(crate) fn http_agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .provider(ureq::tls::TlsProvider::NativeTls)
+                .build(),
+        )
+        .timeout_global(Some(DOWNLOAD_TIMEOUT))
+        .build()
+        .into()
+}
+
+fn http_get(url: &str) -> Option<Vec<u8>> {
+    let mut resp = http_agent().get(url).call().ok()?;
+    if resp.status() != 200 {
+        return None;
+    }
+    let mut bytes = Vec::new();
+    resp.body_mut()
+        .as_reader()
+        .take(20 * 1024 * 1024)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    Some(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_path_prefers_appid_stem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(tmp.path());
+        std::fs::write(tmp.path().join("appid_123.jpg"), b"x").unwrap();
+        std::fs::write(tmp.path().join("Some Game.png"), b"x").unwrap();
+        assert_eq!(
+            cache.cached_path("Some Game", Some(123)).unwrap(),
+            tmp.path().join("appid_123.jpg")
+        );
+        assert_eq!(
+            cache.cached_path("Some Game", None).unwrap(),
+            tmp.path().join("Some Game.png")
+        );
+    }
+
+    #[test]
+    fn sanitizes_name_stems() {
+        assert_eq!(
+            ImageCache::safe_name("The Witcher 3: Wild Hunt"),
+            "The Witcher 3_ Wild Hunt"
+        );
+    }
+
+    #[test]
+    fn missing_cache_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(tmp.path());
+        assert!(cache.cached_path("Nothing", Some(1)).is_none());
+    }
+}

--- a/rust/crates/opticore/src/lib.rs
+++ b/rust/crates/opticore/src/lib.rs
@@ -1,8 +1,11 @@
 //! OptiScaler-GUI core: game scanning, OptiScaler install management, config.
 //! This crate has zero GUI dependencies so all logic is testable headless.
 
+pub mod appids;
 pub mod archive;
+pub mod images;
 pub mod model;
+pub mod progress;
 pub mod scan;
 
 /// App version (CalVer), single source of truth for the workspace.

--- a/rust/crates/opticore/src/progress.rs
+++ b/rust/crates/opticore/src/progress.rs
@@ -1,0 +1,24 @@
+//! Events flowing from core worker threads to the GUI.
+//! The GUI drains one mpsc receiver at the top of each frame; workers hold
+//! Sender clones and request a repaint after sending.
+
+use crate::model::Game;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum TaskEvent {
+    /// A full scan finished (the scan itself takes ~0.2s, so results arrive
+    /// in one batch rather than streamed per platform).
+    ScanFinished { games: Vec<Game> },
+    /// Artwork for a game is ready on disk.
+    ImageReady {
+        path_norm: String,
+        image_path: PathBuf,
+    },
+    /// Artwork lookup gave up (no appid / download failed) — stop showing a spinner.
+    ImageMissing { path_norm: String },
+    /// The SteamSpy catalogue finished loading — retry missing artwork.
+    AppListReady,
+    /// A log line for the log screen.
+    Log(String),
+}

--- a/rust/crates/optiscaler-gui/Cargo.toml
+++ b/rust/crates/optiscaler-gui/Cargo.toml
@@ -19,6 +19,8 @@ wgpu = { version = "27", default-features = false, features = [
     "vulkan",
     "wgsl",
 ] }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+rfd = { version = "0.15", default-features = false }
 
 [[bin]]
 name = "OptiScaler-GUI"

--- a/rust/crates/optiscaler-gui/src/app.rs
+++ b/rust/crates/optiscaler-gui/src/app.rs
@@ -1,0 +1,123 @@
+//! Top-level app: event draining, sidebar navigation, screen routing.
+
+use crate::ops::Ops;
+use crate::screens;
+use crate::state::{AppState, ArtState, ScanState, Screen};
+use crate::theme;
+use eframe::egui::{self, RichText};
+use opticore::progress::TaskEvent;
+
+pub struct App {
+    state: AppState,
+    ops: Ops,
+    started: bool,
+}
+
+impl App {
+    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        theme::apply(&cc.egui_ctx);
+        Self {
+            state: AppState::default(),
+            ops: Ops::new(),
+            started: false,
+        }
+    }
+
+    fn drain_events(&mut self) {
+        while let Ok(event) = self.ops.rx.try_recv() {
+            match event {
+                TaskEvent::ScanFinished { mut games } => {
+                    games.sort_by(|a, b| a.key.name_lower.cmp(&b.key.name_lower));
+                    self.state.games = games;
+                    self.state.scan_state = ScanState::Done;
+                    self.ops.scan_finished();
+                }
+                TaskEvent::ImageReady {
+                    path_norm,
+                    image_path,
+                } => {
+                    self.state
+                        .art
+                        .insert(path_norm, ArtState::Ready(image_path));
+                }
+                TaskEvent::ImageMissing { path_norm } => {
+                    self.state.art.insert(path_norm, ArtState::Missing);
+                }
+                TaskEvent::AppListReady => {
+                    // Retry artwork that had no appid before the catalogue loaded
+                    self.ops.clear_inflight();
+                    self.state
+                        .art
+                        .retain(|_, art_state| *art_state != ArtState::Missing);
+                    self.state
+                        .push_log("App list ready — retrying missing artwork".into());
+                }
+                TaskEvent::Log(line) => self.state.push_log(line),
+            }
+        }
+    }
+
+    fn sidebar(&mut self, ctx: &egui::Context) {
+        egui::SidePanel::left("sidebar")
+            .exact_width(150.0)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.add_space(10.0);
+                ui.label(
+                    RichText::new("OPTISCALER")
+                        .strong()
+                        .size(15.0)
+                        .color(theme::ACCENT),
+                );
+                ui.label(RichText::new("GUI").size(12.0).color(theme::TEXT_DIM));
+                ui.add_space(16.0);
+
+                for (screen, label) in [
+                    (Screen::Games, "🎮  Games"),
+                    (Screen::Settings, "⚙  Settings"),
+                    (Screen::Log, "📜  Log"),
+                    (Screen::About, "ℹ  About"),
+                ] {
+                    let selected = self.state.screen == screen;
+                    if ui
+                        .selectable_label(selected, RichText::new(label).size(14.0))
+                        .clicked()
+                    {
+                        self.state.screen = screen;
+                    }
+                    ui.add_space(2.0);
+                }
+
+                ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+                    ui.add_space(8.0);
+                    ui.label(
+                        RichText::new(format!("v{}", opticore::VERSION))
+                            .small()
+                            .color(theme::TEXT_DIM),
+                    );
+                });
+            });
+    }
+}
+
+impl eframe::App for App {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.drain_events();
+
+        // First-frame startup: catalogue load + initial scan
+        if !self.started {
+            self.started = true;
+            self.ops.spawn_catalogue_load(ctx);
+            self.state.scan_state = ScanState::Running;
+            self.ops.spawn_scan(ctx);
+        }
+
+        self.sidebar(ctx);
+        match self.state.screen {
+            Screen::Games => screens::games_grid::show(ctx, &mut self.state, &mut self.ops),
+            Screen::Settings => screens::show_settings(ctx, &mut self.state),
+            Screen::Log => screens::show_log(ctx, &mut self.state),
+            Screen::About => screens::show_about(ctx, &mut self.state),
+        }
+    }
+}

--- a/rust/crates/optiscaler-gui/src/main.rs
+++ b/rust/crates/optiscaler-gui/src/main.rs
@@ -1,5 +1,11 @@
-//! OptiScaler GUI (Rust rewrite) — M0 scaffold: dark GPU-rendered window.
+//! OptiScaler GUI (Rust rewrite) — GPU-rendered installer/manager for OptiScaler.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+mod app;
+mod ops;
+mod screens;
+mod state;
+mod theme;
 
 use eframe::egui;
 
@@ -14,23 +20,6 @@ fn main() -> eframe::Result {
     eframe::run_native(
         "OptiScaler GUI",
         options,
-        Box::new(|cc| {
-            cc.egui_ctx.set_visuals(egui::Visuals::dark());
-            Ok(Box::new(App))
-        }),
+        Box::new(|cc| Ok(Box::new(app::App::new(cc)))),
     )
-}
-
-struct App;
-
-impl eframe::App for App {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("OptiScaler GUI");
-            ui.label(format!(
-                "M0 scaffold — GPU-rendered via wgpu — core {}",
-                opticore::VERSION
-            ));
-        });
-    }
 }

--- a/rust/crates/optiscaler-gui/src/ops.rs
+++ b/rust/crates/optiscaler-gui/src/ops.rs
@@ -1,0 +1,122 @@
+//! Background operations: one mpsc channel from worker threads to the GUI.
+//! Workers request a repaint after each send so events render immediately.
+
+use eframe::egui;
+use opticore::appids::AppIdResolver;
+use opticore::images::ImageCache;
+use opticore::model::Game;
+use opticore::progress::TaskEvent;
+use opticore::scan::{scan_all, ScanConfig};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::Arc;
+
+pub struct Ops {
+    pub tx: Sender<TaskEvent>,
+    pub rx: Receiver<TaskEvent>,
+    pub resolver: Arc<AppIdResolver>,
+    pub images: Arc<ImageCache>,
+    inflight_images: HashSet<String>,
+    scan_running: bool,
+}
+
+/// Portable layout: cache lives next to the exe (falls back to cwd in dev),
+/// same `cache/game_images` naming as the Python app so caches carry over.
+fn cache_dir() -> PathBuf {
+    let base = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        .unwrap_or_else(|| PathBuf::from("."));
+    base.join("cache").join("game_images")
+}
+
+impl Ops {
+    pub fn new() -> Self {
+        let (tx, rx) = channel();
+        let dir = cache_dir();
+        Self {
+            tx,
+            rx,
+            resolver: Arc::new(AppIdResolver::new(&dir)),
+            images: Arc::new(ImageCache::new(&dir)),
+            inflight_images: HashSet::new(),
+            scan_running: false,
+        }
+    }
+
+    /// Load the SteamSpy catalogue in the background (skipped if cache fresh).
+    pub fn spawn_catalogue_load(&self, ctx: &egui::Context) {
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        let resolver = self.resolver.clone();
+        std::thread::spawn(move || {
+            if resolver.load_steamspy_catalogue() {
+                let _ = tx.send(TaskEvent::Log("SteamSpy catalogue loaded".into()));
+            }
+            let _ = tx.send(TaskEvent::AppListReady);
+            ctx.request_repaint();
+        });
+    }
+
+    pub fn scan_running(&self) -> bool {
+        self.scan_running
+    }
+
+    pub fn scan_finished(&mut self) {
+        self.scan_running = false;
+    }
+
+    pub fn spawn_scan(&mut self, ctx: &egui::Context) {
+        if self.scan_running {
+            return;
+        }
+        self.scan_running = true;
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        std::thread::spawn(move || {
+            let t0 = std::time::Instant::now();
+            let result = scan_all(&ScanConfig::default());
+            let _ = tx.send(TaskEvent::Log(format!(
+                "Scan finished: {} games in {:.2}s",
+                result.games.len(),
+                t0.elapsed().as_secs_f32()
+            )));
+            let _ = tx.send(TaskEvent::ScanFinished {
+                games: result.games,
+            });
+            ctx.request_repaint();
+        });
+    }
+
+    /// Fetch artwork for one game (deduped per path).
+    pub fn request_image(&mut self, ctx: &egui::Context, game: &Game) {
+        let key = game.key.path_norm.clone();
+        if !self.inflight_images.insert(key.clone()) {
+            return;
+        }
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        let resolver = self.resolver.clone();
+        let images = self.images.clone();
+        let name = game.name.clone();
+        let appid = game.steam_appid;
+        std::thread::spawn(move || {
+            let appid = appid.or_else(|| resolver.lookup(&name));
+            let event = match images.fetch(&name, appid) {
+                Some(path) => TaskEvent::ImageReady {
+                    path_norm: key,
+                    image_path: path,
+                },
+                None => TaskEvent::ImageMissing { path_norm: key },
+            };
+            let _ = tx.send(event);
+            ctx.request_repaint();
+        });
+    }
+
+    /// Allow re-requesting images (after AppListReady retry-reset).
+    pub fn clear_inflight(&mut self) {
+        self.inflight_images.clear();
+    }
+}

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -197,7 +197,7 @@ fn card(ui: &mut egui::Ui, ctx: &egui::Context, state: &mut AppState, ops: &mut 
         theme::CARD
     };
     let stroke = if selected {
-        Stroke::new(1.5, theme::ACCENT)
+        Stroke::new(1.5_f32, theme::ACCENT)
     } else {
         Stroke::NONE
     };

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -1,0 +1,377 @@
+//! Games screen: toolbar (search / platform filter / rescan / add folder),
+//! virtualized responsive card grid, and a detail side panel.
+
+use crate::ops::Ops;
+use crate::state::{AppState, ArtState, ScanState};
+use crate::theme;
+use eframe::egui::{self, Align, Color32, CornerRadius, Layout, RichText, Sense, Stroke, Vec2};
+use opticore::model::{Engine, Game, Platform};
+use opticore::progress::TaskEvent;
+
+const CARD_W: f32 = 210.0;
+const CARD_H: f32 = 158.0;
+const ART_H: f32 = 92.0;
+const GRID_GAP: f32 = 10.0;
+
+const PLATFORM_FILTERS: &[(Option<Platform>, &str)] = &[
+    (None, "All platforms"),
+    (Some(Platform::Steam), "Steam"),
+    (Some(Platform::Epic), "Epic"),
+    (Some(Platform::Gog), "GOG"),
+    (Some(Platform::Xbox), "Xbox"),
+    (Some(Platform::Heroic), "Heroic"),
+    (Some(Platform::Manual), "Manual"),
+];
+
+pub fn show(ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
+    // Detail side panel for the selected game
+    if let Some(selected_key) = state.selected.clone() {
+        let game = state
+            .games
+            .iter()
+            .find(|g| g.key.path_norm == selected_key)
+            .cloned();
+        if let Some(game) = game {
+            egui::SidePanel::right("game_detail")
+                .default_width(300.0)
+                .show(ctx, |ui| detail_panel(ui, ctx, state, &game));
+        } else {
+            state.selected = None;
+        }
+    }
+
+    egui::CentralPanel::default().show(ctx, |ui| {
+        toolbar(ui, ctx, state, ops);
+        ui.add_space(4.0);
+
+        match state.scan_state {
+            ScanState::NotStarted => {
+                empty_state(
+                    ui,
+                    ctx,
+                    ops,
+                    "Welcome! Scan your system to find installed games.",
+                );
+            }
+            ScanState::Running => {
+                ui.vertical_centered(|ui| {
+                    ui.add_space(60.0);
+                    ui.spinner();
+                    ui.label(RichText::new("Scanning for games…").color(theme::TEXT_DIM));
+                });
+            }
+            ScanState::Done => {
+                let indices = state.filtered_indices();
+                if indices.is_empty() {
+                    empty_state(ui, ctx, ops, "No games match the current search/filter.");
+                } else {
+                    grid(ui, ctx, state, ops, &indices);
+                }
+            }
+        }
+    });
+}
+
+fn toolbar(ui: &mut egui::Ui, ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
+    ui.horizontal(|ui| {
+        ui.add(
+            egui::TextEdit::singleline(&mut state.search)
+                .hint_text("Search games…")
+                .desired_width(220.0),
+        );
+
+        let current_label = PLATFORM_FILTERS
+            .iter()
+            .find(|(p, _)| *p == state.platform_filter)
+            .map(|(_, l)| *l)
+            .unwrap_or("All platforms");
+        egui::ComboBox::from_id_salt("platform_filter")
+            .selected_text(current_label)
+            .show_ui(ui, |ui| {
+                for (platform, label) in PLATFORM_FILTERS {
+                    ui.selectable_value(&mut state.platform_filter, *platform, *label);
+                }
+            });
+
+        if ui
+            .add_enabled(!ops.scan_running(), egui::Button::new("⟳ Rescan"))
+            .clicked()
+        {
+            state.scan_state = ScanState::Running;
+            ops.spawn_scan(ctx);
+        }
+
+        if ui.button("📁 Add folder…").clicked() {
+            if let Some(folder) = rfd::FileDialog::new().pick_folder() {
+                match opticore::scan::scan_manual_folder(&folder) {
+                    Some(game) => {
+                        let _ = ops
+                            .tx
+                            .send(TaskEvent::Log(format!("Added manual game: {}", game.name)));
+                        // replace existing entry for the same path
+                        state
+                            .games
+                            .retain(|g| g.key.path_norm != game.key.path_norm);
+                        state.games.push(game);
+                        state
+                            .games
+                            .sort_by(|a, b| a.key.name_lower.cmp(&b.key.name_lower));
+                    }
+                    None => {
+                        let _ = ops.tx.send(TaskEvent::Log(format!(
+                            "Folder does not look like a game: {}",
+                            folder.display()
+                        )));
+                    }
+                }
+            }
+        }
+
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            if state.scan_state == ScanState::Done {
+                ui.label(
+                    RichText::new(format!("{} games", state.filtered_indices().len()))
+                        .color(theme::TEXT_DIM),
+                );
+            }
+        });
+    });
+}
+
+fn empty_state(ui: &mut egui::Ui, ctx: &egui::Context, ops: &mut Ops, message: &str) {
+    ui.vertical_centered(|ui| {
+        ui.add_space(80.0);
+        ui.label(RichText::new(message).size(16.0).color(theme::TEXT_DIM));
+        ui.add_space(12.0);
+        if !ops.scan_running()
+            && ui
+                .add(egui::Button::new(
+                    RichText::new("🔍 Scan for games").size(16.0),
+                ))
+                .clicked()
+        {
+            ops.spawn_scan(ctx);
+        }
+    });
+}
+
+fn grid(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    state: &mut AppState,
+    ops: &mut Ops,
+    indices: &[usize],
+) {
+    let avail = ui.available_width();
+    let cols = ((avail + GRID_GAP) / (CARD_W + GRID_GAP)).floor().max(1.0) as usize;
+    let rows = indices.len().div_ceil(cols);
+    let row_height = CARD_H + GRID_GAP;
+
+    egui::ScrollArea::vertical()
+        .auto_shrink([false, false])
+        .show_rows(ui, row_height, rows, |ui, row_range| {
+            for row in row_range {
+                ui.horizontal(|ui| {
+                    for col in 0..cols {
+                        let Some(&game_idx) = indices.get(row * cols + col) else {
+                            break;
+                        };
+                        let game = state.games[game_idx].clone();
+                        card(ui, ctx, state, ops, &game);
+                    }
+                });
+            }
+        });
+}
+
+fn card(ui: &mut egui::Ui, ctx: &egui::Context, state: &mut AppState, ops: &mut Ops, game: &Game) {
+    let (rect, response) = ui.allocate_exact_size(Vec2::new(CARD_W, CARD_H), Sense::click());
+    if !ui.is_rect_visible(rect) {
+        return;
+    }
+
+    let selected = state.selected.as_deref() == Some(game.key.path_norm.as_str());
+    let fill = if selected || response.hovered() {
+        theme::CARD_HOVER
+    } else {
+        theme::CARD
+    };
+    let stroke = if selected {
+        Stroke::new(1.5, theme::ACCENT)
+    } else {
+        Stroke::NONE
+    };
+    ui.painter().rect(
+        rect,
+        CornerRadius::same(8),
+        fill,
+        stroke,
+        egui::StrokeKind::Inside,
+    );
+
+    // Artwork area
+    let art_rect = egui::Rect::from_min_size(
+        rect.min + Vec2::new(4.0, 4.0),
+        Vec2::new(CARD_W - 8.0, ART_H),
+    );
+    match state.art_state(&game.key.path_norm) {
+        ArtState::Ready(image_path) => {
+            if let Some(texture) = state.texture_for(ctx, &image_path) {
+                ui.painter().image(
+                    texture.id(),
+                    art_rect,
+                    egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
+                    Color32::WHITE,
+                );
+            }
+        }
+        ArtState::Unknown => {
+            ops.request_image(ctx, game);
+            state
+                .art
+                .insert(game.key.path_norm.clone(), ArtState::Fetching);
+            placeholder_art(ui, art_rect, "…");
+        }
+        ArtState::Fetching => placeholder_art(ui, art_rect, "…"),
+        ArtState::Missing => placeholder_art(ui, art_rect, &game.name),
+    }
+
+    // Name
+    let name_pos = egui::pos2(rect.min.x + 8.0, art_rect.max.y + 8.0);
+    let name = if game.name.chars().count() > 26 {
+        let truncated: String = game.name.chars().take(25).collect();
+        format!("{truncated}…")
+    } else {
+        game.name.clone()
+    };
+    ui.painter().text(
+        name_pos,
+        egui::Align2::LEFT_TOP,
+        name,
+        egui::FontId::proportional(13.0),
+        ui.visuals().text_color(),
+    );
+
+    // Badge row
+    let mut badge_pos = egui::pos2(rect.min.x + 8.0, rect.max.y - 24.0);
+    badge_pos = badge(ui, badge_pos, game.platform.label(), theme::BADGE_PLATFORM);
+    if game.optiscaler_installed {
+        badge_pos = badge(ui, badge_pos, "OptiScaler ✓", theme::BADGE_OK);
+    }
+    if !game.anti_cheat.is_empty() {
+        badge_pos = badge(ui, badge_pos, "⚠ AC", theme::BADGE_WARN);
+    }
+    if !game.engine_supported && game.engine != Engine::Unknown {
+        badge(ui, badge_pos, "engine", theme::BADGE_DANGER);
+    }
+
+    if response.clicked() {
+        state.selected = if selected {
+            None
+        } else {
+            Some(game.key.path_norm.clone())
+        };
+    }
+    ui.add_space(GRID_GAP - ui.spacing().item_spacing.x);
+}
+
+fn placeholder_art(ui: &egui::Ui, rect: egui::Rect, label: &str) {
+    ui.painter()
+        .rect_filled(rect, CornerRadius::same(6), theme::BG);
+    let text = if label.chars().count() > 20 {
+        label.chars().take(19).collect::<String>() + "…"
+    } else {
+        label.to_string()
+    };
+    ui.painter().text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        text,
+        egui::FontId::proportional(12.0),
+        theme::TEXT_DIM,
+    );
+}
+
+fn badge(ui: &egui::Ui, pos: egui::Pos2, text: &str, color: Color32) -> egui::Pos2 {
+    let font = egui::FontId::proportional(10.0);
+    let galley = ui
+        .painter()
+        .layout_no_wrap(text.to_string(), font.clone(), Color32::WHITE);
+    let padding = Vec2::new(6.0, 3.0);
+    let rect = egui::Rect::from_min_size(pos, galley.size() + padding * 2.0);
+    ui.painter().rect_filled(rect, CornerRadius::same(4), color);
+    ui.painter()
+        .galley(rect.min + padding, galley, Color32::WHITE);
+    egui::pos2(rect.max.x + 6.0, pos.y)
+}
+
+fn detail_panel(ui: &mut egui::Ui, ctx: &egui::Context, state: &mut AppState, game: &Game) {
+    ui.add_space(6.0);
+    ui.horizontal(|ui| {
+        ui.heading(&game.name);
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            if ui.button("✕").clicked() {
+                state.selected = None;
+            }
+        });
+    });
+    ui.add_space(4.0);
+
+    if let ArtState::Ready(image_path) = state.art_state(&game.key.path_norm) {
+        if let Some(texture) = state.texture_for(ctx, &image_path) {
+            let w = ui.available_width().min(280.0);
+            let aspect = texture.aspect_ratio();
+            ui.image((texture.id(), Vec2::new(w, w / aspect)));
+        }
+    }
+
+    ui.add_space(8.0);
+    egui::Grid::new("detail_grid")
+        .num_columns(2)
+        .show(ui, |ui| {
+            ui.label(RichText::new("Platform").color(theme::TEXT_DIM));
+            ui.label(game.platform.label());
+            ui.end_row();
+            ui.label(RichText::new("Engine").color(theme::TEXT_DIM));
+            ui.label(format!("{:?}", game.engine));
+            ui.end_row();
+            if let Some(appid) = game.steam_appid {
+                ui.label(RichText::new("Steam AppID").color(theme::TEXT_DIM));
+                ui.label(appid.to_string());
+                ui.end_row();
+            }
+            ui.label(RichText::new("OptiScaler").color(theme::TEXT_DIM));
+            ui.label(if game.optiscaler_installed {
+                "Installed"
+            } else {
+                "Not installed"
+            });
+            ui.end_row();
+        });
+
+    if !game.anti_cheat.is_empty() {
+        ui.add_space(6.0);
+        ui.colored_label(
+            theme::BADGE_WARN,
+            format!("⚠ Anti-cheat detected: {:?}", game.anti_cheat),
+        );
+    }
+
+    ui.add_space(8.0);
+    ui.label(
+        RichText::new(game.path.display().to_string())
+            .small()
+            .color(theme::TEXT_DIM),
+    );
+    ui.add_space(8.0);
+
+    ui.horizontal(|ui| {
+        if ui.button("📂 Open folder").clicked() {
+            let _ = std::process::Command::new("explorer")
+                .arg(&game.path)
+                .spawn();
+        }
+        ui.add_enabled(false, egui::Button::new("Install OptiScaler"))
+            .on_disabled_hover_text("Coming in M3");
+    });
+}

--- a/rust/crates/optiscaler-gui/src/screens/mod.rs
+++ b/rust/crates/optiscaler-gui/src/screens/mod.rs
@@ -1,0 +1,57 @@
+pub mod games_grid;
+
+use crate::state::AppState;
+use crate::theme;
+use eframe::egui::{self, RichText};
+
+pub fn show_settings(ctx: &egui::Context, _state: &mut AppState) {
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.heading("Settings");
+        ui.add_space(8.0);
+        ui.label(
+            RichText::new(
+                "Language, theme, effects toggle, cache management and more arrive in M5.",
+            )
+            .color(theme::TEXT_DIM),
+        );
+    });
+}
+
+pub fn show_log(ctx: &egui::Context, state: &mut AppState) {
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.horizontal(|ui| {
+            ui.heading("Log");
+            if ui.button("Copy all").clicked() {
+                let all: String = state.log.iter().cloned().collect::<Vec<_>>().join("\n");
+                ctx.copy_text(all);
+            }
+        });
+        ui.add_space(4.0);
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, false])
+            .stick_to_bottom(true)
+            .show(ui, |ui| {
+                for line in &state.log {
+                    ui.label(RichText::new(line).monospace().size(12.0));
+                }
+            });
+    });
+}
+
+pub fn show_about(ctx: &egui::Context, _state: &mut AppState) {
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.heading("OptiScaler GUI");
+        ui.label(format!("Version {}", opticore::VERSION));
+        ui.add_space(8.0);
+        ui.label("An unofficial installer and manager for OptiScaler.");
+        ui.label(
+            RichText::new(
+                "All upscaling technology is the work of the OptiScaler team — this app only installs and manages it.",
+            )
+            .color(theme::TEXT_DIM),
+        );
+        ui.add_space(8.0);
+        ui.hyperlink_to("OptiScaler (official project)", "https://github.com/optiscaler/OptiScaler");
+        ui.hyperlink_to("OptiScaler-GUI on GitHub", "https://github.com/King4s/OptiScaler-GUI");
+    });
+}

--- a/rust/crates/optiscaler-gui/src/state.rs
+++ b/rust/crates/optiscaler-gui/src/state.rs
@@ -1,0 +1,117 @@
+//! GUI state: screens, game list + filters, texture cache, log ring.
+
+use eframe::egui::{self, TextureHandle};
+use opticore::model::{Game, Platform};
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Screen {
+    Games,
+    Settings,
+    Log,
+    About,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanState {
+    NotStarted,
+    Running,
+    Done,
+}
+
+/// Artwork status per game (keyed by Game.key.path_norm).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtState {
+    Unknown,
+    Fetching,
+    Ready(PathBuf),
+    Missing,
+}
+
+const TEXTURE_CACHE_CAP: usize = 128;
+const LOG_CAP: usize = 2000;
+
+pub struct AppState {
+    pub screen: Screen,
+    pub games: Vec<Game>,
+    pub scan_state: ScanState,
+    pub search: String,
+    pub platform_filter: Option<Platform>,
+    pub selected: Option<String>, // path_norm of selected game
+    pub art: HashMap<String, ArtState>,
+    pub log: VecDeque<String>,
+    textures: HashMap<String, TextureHandle>,
+    texture_lru: VecDeque<String>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            screen: Screen::Games,
+            games: Vec::new(),
+            scan_state: ScanState::NotStarted,
+            search: String::new(),
+            platform_filter: None,
+            selected: None,
+            art: HashMap::new(),
+            log: VecDeque::new(),
+            textures: HashMap::new(),
+            texture_lru: VecDeque::new(),
+        }
+    }
+}
+
+impl AppState {
+    pub fn push_log(&mut self, line: String) {
+        if self.log.len() >= LOG_CAP {
+            self.log.pop_front();
+        }
+        self.log.push_back(line);
+    }
+
+    /// Indices of games matching the current search + platform filter.
+    pub fn filtered_indices(&self) -> Vec<usize> {
+        let needle = self.search.to_lowercase();
+        self.games
+            .iter()
+            .enumerate()
+            .filter(|(_, g)| {
+                (needle.is_empty() || g.key.name_lower.contains(&needle))
+                    && self.platform_filter.is_none_or(|p| g.platform == p)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    pub fn art_state(&self, path_norm: &str) -> ArtState {
+        self.art
+            .get(path_norm)
+            .cloned()
+            .unwrap_or(ArtState::Unknown)
+    }
+
+    /// Texture for an artwork file, loading + LRU-evicting as needed.
+    pub fn texture_for(&mut self, ctx: &egui::Context, image_path: &Path) -> Option<TextureHandle> {
+        let key = image_path.to_string_lossy().to_string();
+        if let Some(handle) = self.textures.get(&key) {
+            // refresh LRU position
+            self.texture_lru.retain(|k| k != &key);
+            self.texture_lru.push_back(key);
+            return Some(handle.clone());
+        }
+        let bytes = std::fs::read(image_path).ok()?;
+        let img = image::load_from_memory(&bytes).ok()?.to_rgba8();
+        let size = [img.width() as usize, img.height() as usize];
+        let color = egui::ColorImage::from_rgba_unmultiplied(size, img.as_raw());
+        let handle = ctx.load_texture(&key, color, egui::TextureOptions::LINEAR);
+        self.textures.insert(key.clone(), handle.clone());
+        self.texture_lru.push_back(key);
+        while self.texture_lru.len() > TEXTURE_CACHE_CAP {
+            if let Some(evict) = self.texture_lru.pop_front() {
+                self.textures.remove(&evict);
+            }
+        }
+        Some(handle)
+    }
+}

--- a/rust/crates/optiscaler-gui/src/theme.rs
+++ b/rust/crates/optiscaler-gui/src/theme.rs
@@ -26,7 +26,7 @@ pub fn apply(ctx: &egui::Context) {
     visuals.widgets.inactive.corner_radius = CornerRadius::same(6);
     visuals.widgets.hovered.corner_radius = CornerRadius::same(6);
     visuals.widgets.active.corner_radius = CornerRadius::same(6);
-    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, ACCENT);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, ACCENT);
     ctx.set_visuals(visuals);
 
     let mut style = (*ctx.style()).clone();

--- a/rust/crates/optiscaler-gui/src/theme.rs
+++ b/rust/crates/optiscaler-gui/src/theme.rs
@@ -1,0 +1,36 @@
+//! Dark gaming theme: custom palette on top of egui's dark visuals.
+
+use eframe::egui::{self, Color32, CornerRadius, Stroke};
+
+pub const BG: Color32 = Color32::from_rgb(0x0e, 0x11, 0x16);
+pub const PANEL: Color32 = Color32::from_rgb(0x15, 0x1a, 0x21);
+pub const CARD: Color32 = Color32::from_rgb(0x1b, 0x22, 0x2b);
+pub const CARD_HOVER: Color32 = Color32::from_rgb(0x23, 0x2c, 0x38);
+pub const ACCENT: Color32 = Color32::from_rgb(0x4f, 0x9d, 0xff);
+pub const TEXT_DIM: Color32 = Color32::from_rgb(0x8a, 0x94, 0xa3);
+
+pub const BADGE_PLATFORM: Color32 = Color32::from_rgb(0x2c, 0x36, 0x44);
+pub const BADGE_OK: Color32 = Color32::from_rgb(0x1f, 0x6f, 0x43);
+pub const BADGE_WARN: Color32 = Color32::from_rgb(0x8a, 0x6d, 0x1a);
+pub const BADGE_DANGER: Color32 = Color32::from_rgb(0x8a, 0x2a, 0x2a);
+
+pub fn apply(ctx: &egui::Context) {
+    let mut visuals = egui::Visuals::dark();
+    visuals.panel_fill = PANEL;
+    visuals.window_fill = BG;
+    visuals.extreme_bg_color = BG;
+    visuals.faint_bg_color = CARD;
+    visuals.selection.bg_fill = ACCENT.linear_multiply(0.35);
+    visuals.hyperlink_color = ACCENT;
+    visuals.widgets.noninteractive.corner_radius = CornerRadius::same(6);
+    visuals.widgets.inactive.corner_radius = CornerRadius::same(6);
+    visuals.widgets.hovered.corner_radius = CornerRadius::same(6);
+    visuals.widgets.active.corner_radius = CornerRadius::same(6);
+    visuals.widgets.hovered.bg_stroke = Stroke::new(1.0, ACCENT);
+    ctx.set_visuals(visuals);
+
+    let mut style = (*ctx.style()).clone();
+    style.spacing.item_spacing = egui::vec2(8.0, 8.0);
+    style.spacing.button_padding = egui::vec2(10.0, 6.0);
+    ctx.set_style(style);
+}


### PR DESCRIPTION
Third milestone: the new GUI becomes real — sidebar navigation, a virtualized game card grid with live Steam artwork, and the full AppID/image pipeline, all GPU-rendered.

## What''s new

**opticore**
- `progress` — the worker→GUI event channel (scan finished, image ready/missing, app-list ready, log)
- `appids` — AppID resolution with the Python matching ladder (exact → normalized → edition-suffix stripping → token-subset via a token index), seeded instantly from installed manifests, topped up by the SteamSpy catalogue with the **Python-compatible 7-day disk cache** (`steam_app_list.json`, string appids). Deviation flagged: the difflib fuzzy last-resort step is not ported.
- `images` — artwork fetching with the **Python-compatible `cache/game_images` layout** (`appid_<id>.jpg` + legacy name stems — existing caches carry over between apps), Steam CDN `header.jpg` primary, Store API header/capsule fallback, resized to 300×450 JPEG q85.

**optiscaler-gui**
- Dark gaming theme, persistent left sidebar (Games / Settings / Log / About) — screen state survives navigation, unlike the old destroy-and-rebuild flow
- Games screen: search-as-you-type, platform filter, rescan, manual **Add folder** (native dialog), responsive **virtualized card grid** (`show_rows` — only visible rows bind textures; 128-entry LRU texture cache), cards with artwork, platform/OptiScaler/anti-cheat badges, and a **detail side panel** (install actions arrive in M3)
- First-run auto-scan with spinner + friendly empty states; log screen with ring buffer; About screen with credit to the OptiScaler team

## Gotcha worth remembering
ureq 3 with `default-features = false` + `native-tls` still selects the **Rustls provider at runtime** and panics on the first https call — the agent must set `TlsProvider::NativeTls` explicitly. Found via screenshot verification (artwork threads were dying silently).

## Verification
- Screenshot-verified on the dev machine: 28 games render, Steam titles show real artwork, Xbox titles show name placeholders pending catalogue retry, badges correct (OptiScaler ✓ on the 3 installed games)
- Scan ~0.2 s; release exe **6.43 MB** (within budget); 36 opticore tests; clippy `-D warnings` clean

Next: **M3 — install/update/uninstall end-to-end** (GitHub release download with digest verify, extraction, payload + manifest + rollback, install flow UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)