### PR TITLE
Rust rewrite M3: install, update, and uninstall — cross-compatible with Python installs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -487,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1463,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1784,6 +1805,7 @@ dependencies = [
  "sevenz-rust2",
  "sha2",
  "tempfile",
+ "time",
  "ureq",
  "windows-registry",
 ]
@@ -1959,6 +1981,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppmd-rust"
@@ -2486,6 +2514,38 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/rust/crates/opticore/Cargo.toml
+++ b/rust/crates/opticore/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ureq = { version = "3", default-features = false, features = ["native-tls", "gzip"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-registry = "0.6"

--- a/rust/crates/opticore/examples/manage_cli.rs
+++ b/rust/crates/opticore/examples/manage_cli.rs
@@ -1,0 +1,84 @@
+//! Dev harness: real install/uninstall against a game folder.
+//! Usage:
+//!   cargo run --release -p opticore --example install_cli -- install <game_dir> [target.dll]
+//!   cargo run --release -p opticore --example install_cli -- uninstall <game_dir>
+
+use opticore::install::{uninstall, InstallOptions, InstallStage, Installer};
+use std::path::PathBuf;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let action = args.get(1).map(String::as_str).unwrap_or("");
+    let game_dir = PathBuf::from(args.get(2).expect("game dir argument"));
+
+    match action {
+        "install" => {
+            let mut options = InstallOptions {
+                overwrite: true,
+                ..Default::default()
+            };
+            if let Some(target) = args.get(3) {
+                options.target_filename = target.clone();
+            }
+            let downloads = std::env::temp_dir().join("opticore-downloads");
+            let installer = Installer::new(&downloads);
+            let result = installer.install(&game_dir, &options, |stage| match stage {
+                InstallStage::FetchingRelease => println!("STAGE fetching release"),
+                InstallStage::Downloading { done, total } => {
+                    if total > 0 && done % (8 * 1024 * 1024) < 65536 {
+                        println!("STAGE downloading {}%", done * 100 / total);
+                    }
+                }
+                InstallStage::Extracting => println!("STAGE extracting"),
+                InstallStage::CopyingPayload { done, total } => {
+                    if done == total {
+                        println!("STAGE payload {done}/{total}");
+                    }
+                }
+                InstallStage::Finalizing => println!("STAGE finalizing"),
+            });
+            match result {
+                Ok(manifest) => {
+                    println!(
+                        "INSTALL_OK version={} target={} files={} dirs={}",
+                        manifest.optiscaler_version,
+                        manifest.target_filename,
+                        manifest.files.len(),
+                        manifest.directories.len()
+                    );
+                }
+                Err(e) => {
+                    eprintln!("INSTALL_FAILED: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        "update" => {
+            let downloads = std::env::temp_dir().join("opticore-downloads");
+            let installer = Installer::new(&downloads);
+            match installer.update(&game_dir, "auto", |_| {}) {
+                Ok(manifest) => println!(
+                    "UPDATE_OK version={} target={}",
+                    manifest.optiscaler_version, manifest.target_filename
+                ),
+                Err(e) => {
+                    eprintln!("UPDATE_FAILED: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        "uninstall" => match uninstall(&game_dir) {
+            Ok((files, dirs)) => {
+                println!("UNINSTALL_OK files={} dirs={}", files.len(), dirs.len());
+            }
+            Err(e) => {
+                eprintln!("UNINSTALL_FAILED: {e}");
+                std::process::exit(1);
+            }
+        },
+        other => {
+            eprintln!("unknown action: {other}");
+            std::process::exit(2);
+        }
+    }
+}

--- a/rust/crates/opticore/src/install/github.rs
+++ b/rust/crates/opticore/src/install/github.rs
@@ -1,0 +1,225 @@
+//! OptiScaler release download: latest-release lookup, archive asset pick,
+//! streaming download with SHA256 digest verification, reuse of a valid
+//! already-downloaded archive.
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+pub const RELEASES_LATEST_URL: &str =
+    "https://api.github.com/repos/optiscaler/OptiScaler/releases/latest";
+const ARCHIVE_EXTENSIONS: &[&str] = &[".7z", ".zip"];
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReleaseInfo {
+    #[serde(default)]
+    pub tag_name: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub html_url: Option<String>,
+    #[serde(default)]
+    pub assets: Vec<AssetInfo>,
+}
+
+impl ReleaseInfo {
+    pub fn version_label(&self) -> String {
+        self.tag_name
+            .clone()
+            .or_else(|| self.name.clone())
+            .unwrap_or_else(|| "Unknown".to_string())
+    }
+
+    /// First asset with an archive extension (same rule as the Python app).
+    pub fn archive_asset(&self) -> Option<&AssetInfo> {
+        self.assets.iter().find(|a| {
+            let lower = a.name.to_lowercase();
+            ARCHIVE_EXTENSIONS.iter().any(|ext| lower.ends_with(ext))
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AssetInfo {
+    pub name: String,
+    pub browser_download_url: String,
+    #[serde(default)]
+    pub size: u64,
+    /// "sha256:<hex>" when GitHub provides it
+    #[serde(default)]
+    pub digest: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum DownloadError {
+    Network(String),
+    NoArchiveAsset,
+    DigestMismatch,
+    Io(String),
+}
+
+impl std::fmt::Display for DownloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DownloadError::Network(e) => write!(f, "network error: {e}"),
+            DownloadError::NoArchiveAsset => write!(f, "release has no archive asset"),
+            DownloadError::DigestMismatch => {
+                write!(f, "downloaded file failed SHA256 verification")
+            }
+            DownloadError::Io(e) => write!(f, "io error: {e}"),
+        }
+    }
+}
+impl std::error::Error for DownloadError {}
+
+pub fn fetch_latest_release() -> Result<ReleaseInfo, DownloadError> {
+    fetch_release_from(RELEASES_LATEST_URL)
+}
+
+pub fn fetch_release_from(url: &str) -> Result<ReleaseInfo, DownloadError> {
+    let mut resp = crate::images::http_agent()
+        .get(url)
+        .header("User-Agent", "OptiScaler-GUI")
+        .call()
+        .map_err(|e| DownloadError::Network(e.to_string()))?;
+    let body = resp
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| DownloadError::Network(e.to_string()))?;
+    serde_json::from_str(&body).map_err(|e| DownloadError::Network(format!("bad response: {e}")))
+}
+
+/// Verify a file against a GitHub "sha256:<hex>" digest. Files without a
+/// digest pass (same policy as Python).
+pub fn verify_digest(path: &Path, digest: Option<&str>) -> Result<(), DownloadError> {
+    let Some(digest) = digest else {
+        return Ok(());
+    };
+    let Some((algo, expected)) = digest.split_once(':') else {
+        return Ok(()); // unsupported format — skip, like Python
+    };
+    if !algo.eq_ignore_ascii_case("sha256") || expected.is_empty() {
+        return Ok(());
+    }
+    let mut file = std::fs::File::open(path).map_err(|e| DownloadError::Io(e.to_string()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 1024 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| DownloadError::Io(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let actual = hex_encode(&hasher.finalize());
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(DownloadError::DigestMismatch)
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Download the release archive into `download_dir`, reusing an existing
+/// digest-valid file. Progress callback receives (downloaded, total) bytes.
+pub fn download_archive(
+    release: &ReleaseInfo,
+    download_dir: &Path,
+    mut progress: impl FnMut(u64, u64),
+) -> Result<PathBuf, DownloadError> {
+    let asset = release
+        .archive_asset()
+        .ok_or(DownloadError::NoArchiveAsset)?;
+    std::fs::create_dir_all(download_dir).map_err(|e| DownloadError::Io(e.to_string()))?;
+    let target = download_dir.join(&asset.name);
+
+    // Reuse a valid existing download
+    if target.exists() {
+        let size_ok =
+            asset.size == 0 || target.metadata().map(|m| m.len()).unwrap_or(0) == asset.size;
+        if verify_digest(&target, asset.digest.as_deref()).is_ok() && size_ok {
+            return Ok(target);
+        }
+        let _ = std::fs::remove_file(&target);
+    }
+
+    let mut resp = crate::images::http_agent()
+        .get(&asset.browser_download_url)
+        .header("User-Agent", "OptiScaler-GUI")
+        .call()
+        .map_err(|e| DownloadError::Network(e.to_string()))?;
+    let total = asset.size;
+    let mut out = std::fs::File::create(&target).map_err(|e| DownloadError::Io(e.to_string()))?;
+    let mut reader = resp.body_mut().as_reader();
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut downloaded: u64 = 0;
+    loop {
+        let n = reader
+            .read(&mut buf)
+            .map_err(|e| DownloadError::Network(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        std::io::Write::write_all(&mut out, &buf[..n])
+            .map_err(|e| DownloadError::Io(e.to_string()))?;
+        downloaded += n as u64;
+        progress(downloaded, total);
+    }
+    drop(out);
+
+    if total > 0 && std::fs::metadata(&target).map(|m| m.len()).unwrap_or(0) != total {
+        let _ = std::fs::remove_file(&target);
+        return Err(DownloadError::Network("download size mismatch".into()));
+    }
+    if let Err(e) = verify_digest(&target, asset.digest.as_deref()) {
+        let _ = std::fs::remove_file(&target);
+        return Err(e);
+    }
+    Ok(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn picks_first_archive_asset() {
+        let release: ReleaseInfo = serde_json::from_str(
+            r#"{"tag_name":"v0.9.3","assets":[
+                {"name":"notes.txt","browser_download_url":"u1"},
+                {"name":"Optiscaler_0.9.3.7z","browser_download_url":"u2","size":10,
+                 "digest":"sha256:abc"},
+                {"name":"other.zip","browser_download_url":"u3"}
+            ]}"#,
+        )
+        .unwrap();
+        assert_eq!(release.archive_asset().unwrap().name, "Optiscaler_0.9.3.7z");
+        assert_eq!(release.version_label(), "v0.9.3");
+    }
+
+    #[test]
+    fn digest_verification() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("x.bin");
+        let mut f = std::fs::File::create(&file).unwrap();
+        f.write_all(b"hello").unwrap();
+        drop(f);
+        // sha256("hello")
+        let good = "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        assert!(verify_digest(&file, Some(good)).is_ok());
+        assert!(matches!(
+            verify_digest(&file, Some("sha256:deadbeef")),
+            Err(DownloadError::DigestMismatch)
+        ));
+        // no digest / unsupported algo pass
+        assert!(verify_digest(&file, None).is_ok());
+        assert!(verify_digest(&file, Some("md5:abc")).is_ok());
+    }
+}

--- a/rust/crates/opticore/src/install/manifest.rs
+++ b/rust/crates/opticore/src/install/manifest.rs
@@ -1,0 +1,135 @@
+//! Install manifest — schema v1, byte-compatible with the Python app's
+//! `.optiscaler-gui-install.json` so either app can update/uninstall
+//! installations made by the other. THE cross-version contract.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+pub const MANIFEST_FILENAME: &str = ".optiscaler-gui-install.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallManifest {
+    pub schema_version: u32,
+    pub installed_by: String,
+    /// ISO 8601 local time, matching Python's datetime.now().isoformat()
+    pub installed_at: String,
+    pub target_filename: String,
+    pub optiscaler_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_url: Option<String>,
+    /// Forward-slash relative paths, sorted & deduped
+    pub files: Vec<String>,
+    pub directories: Vec<String>,
+}
+
+impl InstallManifest {
+    pub fn new(
+        target_filename: &str,
+        files: &[String],
+        directories: &[String],
+        version: &str,
+        release_url: Option<String>,
+        installed_at: String,
+    ) -> Self {
+        let files: BTreeSet<String> = files
+            .iter()
+            .filter(|f| !f.is_empty())
+            .map(|f| f.replace('\\', "/"))
+            .collect();
+        let directories: BTreeSet<String> = directories
+            .iter()
+            .filter(|d| !d.is_empty())
+            .map(|d| d.replace('\\', "/"))
+            .collect();
+        Self {
+            schema_version: 1,
+            installed_by: "OptiScaler-GUI".to_string(),
+            installed_at,
+            target_filename: target_filename.to_string(),
+            optiscaler_version: version.to_string(),
+            release_url,
+            files: files.into_iter().collect(),
+            directories: directories.into_iter().collect(),
+        }
+    }
+}
+
+pub fn manifest_path(install_dir: &Path) -> PathBuf {
+    install_dir.join(MANIFEST_FILENAME)
+}
+
+pub fn read(install_dir: &Path) -> Option<InstallManifest> {
+    let content = std::fs::read_to_string(manifest_path(install_dir)).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+pub fn write(install_dir: &Path, manifest: &InstallManifest) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(manifest)?;
+    std::fs::write(manifest_path(install_dir), json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fixture produced by the actual Python `_write_install_manifest`.
+    const PYTHON_MANIFEST: &str = include_str!("../../tests/fixtures/python_manifest.json");
+
+    #[test]
+    fn reads_python_written_manifest() {
+        let m: InstallManifest = serde_json::from_str(PYTHON_MANIFEST).expect("parse");
+        assert_eq!(m.schema_version, 1);
+        assert_eq!(m.installed_by, "OptiScaler-GUI");
+        assert_eq!(m.target_filename, "dxgi.dll");
+        assert_eq!(m.optiscaler_version, "v0.9.3");
+        assert!(m.files.contains(&"D3D12_Optiscaler/plugin.dll".to_string()));
+        assert_eq!(m.directories, vec!["D3D12_Optiscaler", "Licenses"]);
+    }
+
+    #[test]
+    fn writes_python_compatible_fields() {
+        let m = InstallManifest::new(
+            "dxgi.dll",
+            &["dxgi.dll".into(), "sub\\file.dll".into(), "".into()],
+            &["Licenses".into()],
+            "v0.9.3",
+            Some("https://example.com".into()),
+            "2026-07-12T12:00:00".into(),
+        );
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        // exact key set the Python reader expects
+        for key in [
+            "schema_version",
+            "installed_by",
+            "installed_at",
+            "target_filename",
+            "optiscaler_version",
+            "release_url",
+            "files",
+            "directories",
+        ] {
+            assert!(value.get(key).is_some(), "missing key {key}");
+        }
+        // backslashes normalized, empty entries dropped, sorted
+        assert_eq!(m.files, vec!["dxgi.dll", "sub/file.dll"]);
+    }
+
+    #[test]
+    fn roundtrip_via_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let m = InstallManifest::new(
+            "winmm.dll",
+            &["winmm.dll".into()],
+            &[],
+            "v0.9.3",
+            None,
+            "2026-07-12T12:00:00".into(),
+        );
+        write(tmp.path(), &m).unwrap();
+        let back = read(tmp.path()).unwrap();
+        assert_eq!(back.target_filename, "winmm.dll");
+        assert_eq!(back.files, vec!["winmm.dll"]);
+    }
+}

--- a/rust/crates/opticore/src/install/mod.rs
+++ b/rust/crates/opticore/src/install/mod.rs
@@ -1,0 +1,507 @@
+//! Install / update / uninstall orchestration. Port of the Python
+//! `OptiScalerManager` flow: download → verify → extract → payload copy →
+//! uninstaller + config + manifest, with rollback on failure.
+
+pub mod github;
+pub mod manifest;
+pub mod payload;
+
+use crate::archive;
+use github::ReleaseInfo;
+use manifest::InstallManifest;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct InstallOptions {
+    pub target_filename: String,
+    pub overwrite: bool,
+    /// GPU type written to a freshly created OptiScaler.ini ("auto"/"nvidia"/"amd"/"intel")
+    pub gpu_type: String,
+    /// v0.7.9+ DLSS-inputs semantics: when the user answers "No" on an
+    /// AMD/Intel setup, only Dxgi=false is written to the config.
+    pub dlss_inputs: bool,
+}
+
+impl Default for InstallOptions {
+    fn default() -> Self {
+        Self {
+            target_filename: "dxgi.dll".to_string(),
+            overwrite: false,
+            gpu_type: "auto".to_string(),
+            dlss_inputs: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum InstallStage {
+    FetchingRelease,
+    Downloading { done: u64, total: u64 },
+    Extracting,
+    CopyingPayload { done: usize, total: usize },
+    Finalizing,
+}
+
+#[derive(Debug)]
+pub enum InstallError {
+    Download(github::DownloadError),
+    Extraction(String),
+    TargetExists(String),
+    DllNotFound,
+    Io(String),
+}
+
+impl std::fmt::Display for InstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InstallError::Download(e) => write!(f, "download failed: {e}"),
+            InstallError::Extraction(e) => write!(f, "extraction failed: {e}"),
+            InstallError::TargetExists(name) => {
+                write!(
+                    f,
+                    "target file {name} already exists (enable overwrite to update)"
+                )
+            }
+            InstallError::DllNotFound => {
+                write!(f, "OptiScaler.dll not found in the release payload")
+            }
+            InstallError::Io(e) => write!(f, "io error: {e}"),
+        }
+    }
+}
+impl std::error::Error for InstallError {}
+
+/// ISO-8601 local timestamp like Python's datetime.now().isoformat().
+fn iso_now() -> String {
+    let now = time::OffsetDateTime::now_local().unwrap_or_else(|_| time::OffsetDateTime::now_utc());
+    let format = time::macros::format_description!(
+        "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:6]"
+    );
+    now.format(&format)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00.000000".to_string())
+}
+
+fn compact_now() -> String {
+    let now = time::OffsetDateTime::now_local().unwrap_or_else(|_| time::OffsetDateTime::now_utc());
+    let format = time::macros::format_description!("[year][month][day]-[hour][minute][second]");
+    now.format(&format)
+        .unwrap_or_else(|_| "00000000-000000".to_string())
+}
+
+pub struct Installer {
+    pub download_dir: PathBuf,
+}
+
+impl Installer {
+    pub fn new(download_dir: &Path) -> Self {
+        Self {
+            download_dir: download_dir.to_path_buf(),
+        }
+    }
+
+    /// Download (or reuse) the latest release archive and extract it.
+    /// Returns (extracted payload dir, release info).
+    pub fn prepare_payload(
+        &self,
+        mut progress: impl FnMut(InstallStage),
+    ) -> Result<(PathBuf, ReleaseInfo), InstallError> {
+        progress(InstallStage::FetchingRelease);
+        let release = github::fetch_latest_release().map_err(InstallError::Download)?;
+        let archive_path = github::download_archive(&release, &self.download_dir, |done, total| {
+            progress(InstallStage::Downloading { done, total })
+        })
+        .map_err(InstallError::Download)?;
+
+        progress(InstallStage::Extracting);
+        let extract_dir = self.download_dir.join("extracted").join(
+            archive_path
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default(),
+        );
+        // Fresh extraction dir per archive version; reuse if already populated
+        if !extract_dir.join("OptiScaler.dll").exists() {
+            std::fs::create_dir_all(&extract_dir).map_err(|e| InstallError::Io(e.to_string()))?;
+            let absolute = extract_dir
+                .canonicalize()
+                .map_err(|e| InstallError::Io(e.to_string()))?;
+            archive::extract_7z(&archive_path, &absolute)
+                .map_err(|e| InstallError::Extraction(e.to_string()))?;
+        }
+        Ok((extract_dir, release))
+    }
+
+    /// Full install into a game directory. Port of `install_optiscaler`.
+    pub fn install(
+        &self,
+        game_path: &Path,
+        options: &InstallOptions,
+        mut progress: impl FnMut(InstallStage),
+    ) -> Result<InstallManifest, InstallError> {
+        let (extracted, release) = self.prepare_payload(&mut progress)?;
+        payload::remove_setup_markers(&extracted);
+
+        let dest_dir = payload::determine_install_directory(game_path);
+        std::fs::create_dir_all(&dest_dir).map_err(|e| InstallError::Io(e.to_string()))?;
+
+        let target_path = dest_dir.join(&options.target_filename);
+        if target_path.exists() {
+            if !options.overwrite {
+                return Err(InstallError::TargetExists(options.target_filename.clone()));
+            }
+            std::fs::remove_file(&target_path).map_err(|e| InstallError::Io(e.to_string()))?;
+        }
+        if options.overwrite {
+            payload::remove_stale_legacy_files(&dest_dir, &options.target_filename);
+            payload::backup_existing_config(&dest_dir, &compact_now());
+        }
+
+        let mut op_files: Vec<String> = Vec::new();
+        let mut op_dirs: Vec<String> = Vec::new();
+        let result = (|| {
+            let dll = payload::find_optiscaler_dll(&extracted).ok_or(InstallError::DllNotFound)?;
+            std::fs::copy(&dll, &target_path).map_err(|e| InstallError::Io(e.to_string()))?;
+            op_files.push(options.target_filename.clone());
+
+            let copied = payload::copy_release_payload(&extracted, &dest_dir, |done, total| {
+                progress(InstallStage::CopyingPayload { done, total })
+            })
+            .map_err(|e| InstallError::Io(e.to_string()))?;
+            op_files.extend(copied.files.iter().cloned());
+            op_dirs.extend(copied.directories.iter().cloned());
+
+            progress(InstallStage::Finalizing);
+            payload::create_uninstaller_script(&dest_dir, &op_files)
+                .map_err(|e| InstallError::Io(e.to_string()))?;
+            op_files.push("Remove OptiScaler.bat".to_string());
+
+            if !dest_dir.join("OptiScaler.ini").exists() {
+                payload::create_default_config(&dest_dir, &options.gpu_type)
+                    .map_err(|e| InstallError::Io(e.to_string()))?;
+                op_files.push("OptiScaler.ini".to_string());
+            }
+            // v0.7.9 DLSS-inputs semantics: "No" → force Dxgi=false in the config
+            if !options.dlss_inputs {
+                set_ini_value(
+                    &dest_dir.join("OptiScaler.ini"),
+                    "Spoofing",
+                    "Dxgi",
+                    "false",
+                )
+                .map_err(|e| InstallError::Io(e.to_string()))?;
+            }
+
+            let manifest = InstallManifest::new(
+                &options.target_filename,
+                &op_files,
+                &op_dirs,
+                &release.version_label(),
+                release.html_url.clone(),
+                iso_now(),
+            );
+            manifest::write(&dest_dir, &manifest).map_err(|e| InstallError::Io(e.to_string()))?;
+            Ok(manifest)
+        })();
+
+        if result.is_err() {
+            payload::rollback(&dest_dir, &op_files, &op_dirs);
+        }
+        result
+    }
+}
+
+/// Uninstall using the manifest when present, else the legacy known-file list.
+/// Port of `uninstall_optiscaler`. Returns the removed files/dirs.
+pub fn uninstall(game_path: &Path) -> Result<(Vec<String>, Vec<String>), InstallError> {
+    let install_dir = payload::determine_install_directory(game_path);
+    let root = install_dir
+        .canonicalize()
+        .unwrap_or_else(|_| install_dir.clone());
+    let mut removed_files = Vec::new();
+    let mut removed_dirs = Vec::new();
+
+    if let Some(m) = manifest::read(&install_dir) {
+        let mut files: Vec<String> = m.files.clone();
+        files.extend([
+            manifest::MANIFEST_FILENAME.to_string(),
+            "Remove OptiScaler.bat".to_string(),
+            "OptiScaler.log".to_string(),
+        ]);
+        files.sort();
+        files.dedup();
+        for rel in &files {
+            let path = install_dir.join(rel);
+            if payload::path_within(&path, &root)
+                && path.is_file()
+                && std::fs::remove_file(&path).is_ok()
+            {
+                removed_files.push(rel.clone());
+            }
+        }
+        let mut dirs = m.directories.clone();
+        dirs.sort_by_key(|d| std::cmp::Reverse(d.len()));
+        for rel in &dirs {
+            let path = install_dir.join(rel);
+            if payload::path_within(&path, &root)
+                && path.is_dir()
+                && std::fs::remove_dir_all(&path).is_ok()
+            {
+                removed_dirs.push(rel.clone());
+            }
+        }
+        if !removed_files.is_empty() || !removed_dirs.is_empty() {
+            return Ok((removed_files, removed_dirs));
+        }
+    }
+
+    // Legacy fallback: known file list + proxy names
+    let mut legacy: Vec<&str> = payload::LEGACY_UNINSTALL_FILES.to_vec();
+    legacy.extend(payload::PROXY_FILENAMES);
+    legacy.sort();
+    legacy.dedup();
+    for filename in legacy {
+        let path = install_dir.join(filename);
+        if path.is_file() && std::fs::remove_file(&path).is_ok() {
+            removed_files.push(filename.to_string());
+        }
+    }
+    for dirname in payload::LEGACY_UNINSTALL_DIRS {
+        let path = install_dir.join(dirname);
+        if path.is_dir() && std::fs::remove_dir_all(&path).is_ok() {
+            removed_dirs.push(dirname.to_string());
+        }
+    }
+    if removed_files.is_empty() && removed_dirs.is_empty() {
+        return Err(InstallError::Io(
+            "no OptiScaler files found to remove".into(),
+        ));
+    }
+    Ok((removed_files, removed_dirs))
+}
+
+/// Version recorded in an existing install's manifest, if any.
+pub fn installed_version(game_path: &Path) -> Option<String> {
+    let install_dir = payload::determine_install_directory(game_path);
+    manifest::read(&install_dir).map(|m| m.optiscaler_version)
+}
+
+/// Compare an installed version against the latest release tag.
+/// Tags are "v0.9.3"-style; compares numeric components, tolerant of suffixes.
+pub fn is_update_available(installed: &str, latest: &str) -> bool {
+    fn parts(v: &str) -> Vec<u64> {
+        v.trim_start_matches(['v', 'V'])
+            .split(['.', '-', 'a', 'b'])
+            .map_while(|p| p.parse::<u64>().ok())
+            .collect()
+    }
+    let installed_parts = parts(installed);
+    let latest_parts = parts(latest);
+    if installed_parts.is_empty() || latest_parts.is_empty() {
+        // Unknown versions ("Unknown") — offer update only if labels differ
+        return !installed.eq_ignore_ascii_case(latest);
+    }
+    latest_parts > installed_parts
+}
+
+impl Installer {
+    /// Update an existing install: overwrite with the recorded proxy filename
+    /// (falls back to the given default), config backup + stale cleanup happen
+    /// inside install(). Port of the Python update flow.
+    pub fn update(
+        &self,
+        game_path: &Path,
+        gpu_type: &str,
+        progress: impl FnMut(InstallStage),
+    ) -> Result<InstallManifest, InstallError> {
+        let target = installed_target_filename(game_path).unwrap_or_else(|| "dxgi.dll".to_string());
+        let options = InstallOptions {
+            target_filename: target,
+            overwrite: true,
+            gpu_type: gpu_type.to_string(),
+            dlss_inputs: true,
+        };
+        self.install(game_path, &options, progress)
+    }
+}
+
+/// Proxy filename recorded for an existing install (manifest first, then
+/// probing known proxy names). Port of `get_installed_target_filename`.
+pub fn installed_target_filename(game_path: &Path) -> Option<String> {
+    let install_dir = payload::determine_install_directory(game_path);
+    if let Some(m) = manifest::read(&install_dir) {
+        if !m.target_filename.is_empty() {
+            return Some(m.target_filename);
+        }
+    }
+    payload::PROXY_FILENAMES
+        .iter()
+        .find(|f| install_dir.join(f).exists())
+        .map(|f| f.to_string())
+}
+
+/// Minimal INI value setter preserving all other lines/comments.
+fn set_ini_value(ini_path: &Path, section: &str, key: &str, value: &str) -> std::io::Result<()> {
+    let content = std::fs::read_to_string(ini_path).unwrap_or_default();
+    let mut out: Vec<String> = Vec::new();
+    let mut in_section = false;
+    let mut replaced = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            if in_section && !replaced {
+                out.push(format!("{key}={value}"));
+                replaced = true;
+            }
+            in_section = trimmed[1..trimmed.len() - 1].eq_ignore_ascii_case(section);
+            out.push(line.to_string());
+            continue;
+        }
+        if in_section && !replaced {
+            if let Some((k, _)) = trimmed.split_once('=') {
+                if k.trim().eq_ignore_ascii_case(key) {
+                    out.push(format!("{key}={value}"));
+                    replaced = true;
+                    continue;
+                }
+            }
+        }
+        out.push(line.to_string());
+    }
+    if !replaced {
+        if !in_section {
+            out.push(format!("[{section}]"));
+        }
+        out.push(format!("{key}={value}"));
+    }
+    std::fs::write(ini_path, out.join("\n") + "\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::io::Write;
+
+    #[test]
+    fn uninstall_follows_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path();
+        for f in ["dxgi.dll", "fakenvapi.dll", "Remove OptiScaler.bat"] {
+            File::create(game.join(f)).unwrap();
+        }
+        fs::create_dir_all(game.join("Licenses")).unwrap();
+        File::create(game.join("Licenses").join("L.txt")).unwrap();
+        File::create(game.join("unrelated.txt")).unwrap();
+
+        let m = InstallManifest::new(
+            "dxgi.dll",
+            &[
+                "dxgi.dll".into(),
+                "fakenvapi.dll".into(),
+                "Licenses/L.txt".into(),
+            ],
+            &["Licenses".into()],
+            "v0.9.3",
+            None,
+            "2026-07-12T12:00:00".into(),
+        );
+        manifest::write(game, &m).unwrap();
+
+        let (files, dirs) = uninstall(game).unwrap();
+        assert!(files.contains(&"dxgi.dll".to_string()));
+        assert!(dirs.contains(&"Licenses".to_string()));
+        assert!(game.join("unrelated.txt").exists()); // untouched
+        assert!(!game.join(manifest::MANIFEST_FILENAME).exists());
+        assert!(!game.join("Licenses").exists());
+    }
+
+    #[test]
+    fn uninstall_python_made_install() {
+        // A manifest written by the actual Python app must drive uninstall
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path();
+        let python_manifest = include_str!("../../tests/fixtures/python_manifest.json");
+        fs::write(game.join(manifest::MANIFEST_FILENAME), python_manifest).unwrap();
+        fs::create_dir_all(game.join("D3D12_Optiscaler")).unwrap();
+        for f in [
+            "dxgi.dll",
+            "OptiScaler.ini",
+            "fakenvapi.dll",
+            "Remove OptiScaler.bat",
+        ] {
+            File::create(game.join(f)).unwrap();
+        }
+        File::create(game.join("D3D12_Optiscaler").join("plugin.dll")).unwrap();
+
+        let (files, dirs) = uninstall(game).unwrap();
+        assert!(files.contains(&"dxgi.dll".to_string()));
+        assert!(files.contains(&"D3D12_Optiscaler/plugin.dll".to_string()));
+        assert!(dirs.contains(&"D3D12_Optiscaler".to_string()));
+        assert!(!game.join("dxgi.dll").exists());
+    }
+
+    #[test]
+    fn uninstall_legacy_without_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path();
+        for f in ["dxgi.dll", "OptiScaler.ini", "libxess.dll"] {
+            File::create(game.join(f)).unwrap();
+        }
+        fs::create_dir_all(game.join("D3D12_Optiscaler")).unwrap();
+        let (files, dirs) = uninstall(game).unwrap();
+        assert!(files.contains(&"dxgi.dll".to_string()));
+        assert!(files.contains(&"libxess.dll".to_string()));
+        assert!(dirs.contains(&"D3D12_Optiscaler".to_string()));
+    }
+
+    #[test]
+    fn installed_target_from_manifest_and_probe() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path();
+        assert_eq!(installed_target_filename(game), None);
+        File::create(game.join("winmm.dll")).unwrap();
+        assert_eq!(
+            installed_target_filename(game).as_deref(),
+            Some("winmm.dll")
+        );
+        let m = InstallManifest::new(
+            "d3d12.dll",
+            &["d3d12.dll".into()],
+            &[],
+            "v0.9.3",
+            None,
+            "t".into(),
+        );
+        manifest::write(game, &m).unwrap();
+        assert_eq!(
+            installed_target_filename(game).as_deref(),
+            Some("d3d12.dll")
+        );
+    }
+
+    #[test]
+    fn update_availability_comparison() {
+        assert!(is_update_available("v0.9.2", "v0.9.3"));
+        assert!(is_update_available("v0.9.3", "v0.10.0"));
+        assert!(!is_update_available("v0.9.3", "v0.9.3"));
+        assert!(!is_update_available("v0.10.0", "v0.9.3"));
+        // unknown installed version: differ → update offered
+        assert!(is_update_available("Unknown", "v0.9.3"));
+        assert!(!is_update_available("Unknown", "Unknown"));
+    }
+
+    #[test]
+    fn ini_value_setter_preserves_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ini = tmp.path().join("OptiScaler.ini");
+        let mut f = File::create(&ini).unwrap();
+        f.write_all(b"[Spoofing]\n; comment\nDxgi=auto\nStreamline=auto\n")
+            .unwrap();
+        drop(f);
+        set_ini_value(&ini, "Spoofing", "Dxgi", "false").unwrap();
+        let content = fs::read_to_string(&ini).unwrap();
+        assert!(content.contains("Dxgi=false"));
+        assert!(content.contains("; comment"));
+        assert!(content.contains("Streamline=auto"));
+    }
+}

--- a/rust/crates/opticore/src/install/payload.rs
+++ b/rust/crates/opticore/src/install/payload.rs
@@ -1,0 +1,346 @@
+//! Payload installation: marker removal, stale legacy cleanup, config
+//! backup, dynamic payload copy, uninstaller script, rollback.
+//! Port of the corresponding OptiScalerManager methods.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Proxy DLL names OptiScaler can be installed as (UI order, dxgi.dll default).
+pub const PROXY_FILENAMES: &[&str] = &[
+    "dxgi.dll",
+    "winmm.dll",
+    "version.dll",
+    "dbghelp.dll",
+    "d3d12.dll",
+    "wininet.dll",
+    "winhttp.dll",
+    "OptiScaler.asi",
+    "nvngx.dll",
+];
+
+/// Files from older OptiScaler layouts removed before installing v0.9+ payloads.
+const STALE_LEGACY_FILES: &[&str] = &["nvapi64.dll", "nvngx.dll"];
+
+/// Release marker files never copied to the game dir.
+const PAYLOAD_EXCLUDED_FILENAMES: &[&str] = &["OptiScaler.dll", super::manifest::MANIFEST_FILENAME];
+const PAYLOAD_EXCLUDED_PREFIXES: &[&str] = &["!!"];
+
+/// Directories the legacy (manifest-less) uninstall removes.
+pub const LEGACY_UNINSTALL_DIRS: &[&str] = &["D3D12_Optiscaler", "DlssOverrides", "Licenses"];
+
+/// Additional files the legacy uninstall removes (with proxies + basics).
+pub const LEGACY_UNINSTALL_FILES: &[&str] = &[
+    "OptiScaler.dll",
+    "OptiScaler.ini",
+    "OptiScaler.log",
+    "Remove OptiScaler.bat",
+    "Setup OptiScaler.bat",
+    "OptiScaler.ini.backup",
+    "amd_fidelityfx_dx12.dll",
+    "amd_fidelityfx_vk.dll",
+    "libxess_dx11.dll",
+    "libxess.dll",
+    "nvngx_dlss.dll",
+    "amd_fidelityfx_dx12_v2.dll",
+    "amd_fidelityfx_vk_v2.dll",
+    "fakenvapi.dll",
+    "fakenvapi.ini",
+    "dlssg_to_fsr3_amd_is_better.dll",
+    "libxell.dll",
+    "libxess_fg.dll",
+    "amd_fidelityfx_framegeneration_dx12.dll",
+    "amd_fidelityfx_upscaler_dx12.dll",
+    "setup_windows.bat",
+    "setup_linux.sh",
+];
+
+/// Unreal Engine games install into Engine/Binaries/Win64, everything else
+/// into the game root. Port of `_determine_install_directory`.
+pub fn determine_install_directory(game_path: &Path) -> PathBuf {
+    let unreal = game_path.join("Engine").join("Binaries").join("Win64");
+    if unreal.is_dir() {
+        unreal
+    } else {
+        game_path.to_path_buf()
+    }
+}
+
+/// Remove "!! EXTRACT ALL FILES !!"-style marker files from the payload.
+pub fn remove_setup_markers(extracted: &Path) {
+    if let Ok(entries) = std::fs::read_dir(extracted) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with("!!") && entry.path().is_file() {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+}
+
+/// Remove files from older OptiScaler layouts (preserving the chosen proxy).
+pub fn remove_stale_legacy_files(dest_dir: &Path, target_filename: &str) {
+    for filename in STALE_LEGACY_FILES {
+        if filename.eq_ignore_ascii_case(target_filename) {
+            continue;
+        }
+        let path = dest_dir.join(filename);
+        if path.exists() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+/// Timestamped backup of an existing OptiScaler.ini before overwrite installs.
+pub fn backup_existing_config(dest_dir: &Path, timestamp: &str) -> Option<PathBuf> {
+    let config = dest_dir.join("OptiScaler.ini");
+    if !config.exists() {
+        return None;
+    }
+    let backup = dest_dir.join(format!("OptiScaler.ini.{timestamp}.backup"));
+    std::fs::copy(&config, &backup).ok()?;
+    Some(backup)
+}
+
+fn should_copy_payload_file(file_name: &str) -> bool {
+    if PAYLOAD_EXCLUDED_FILENAMES
+        .iter()
+        .any(|ex| ex.eq_ignore_ascii_case(file_name))
+    {
+        return false;
+    }
+    !PAYLOAD_EXCLUDED_PREFIXES
+        .iter()
+        .any(|prefix| file_name.starts_with(prefix))
+}
+
+pub struct CopiedPayload {
+    pub files: Vec<String>,
+    pub directories: Vec<String>,
+}
+
+/// Copy the release payload dynamically (everything except OptiScaler.dll
+/// and markers), preserving relative paths. Port of `_copy_release_payload`.
+pub fn copy_release_payload(
+    extracted: &Path,
+    dest_dir: &Path,
+    mut progress: impl FnMut(usize, usize),
+) -> std::io::Result<CopiedPayload> {
+    let mut files_to_copy: Vec<PathBuf> = Vec::new();
+    collect_files(extracted, extracted, &mut files_to_copy)?;
+    files_to_copy.retain(|rel| {
+        rel.file_name()
+            .map(|n| should_copy_payload_file(&n.to_string_lossy()))
+            .unwrap_or(false)
+    });
+
+    let total = files_to_copy.len();
+    let mut copied_files = Vec::new();
+    let mut copied_dirs: BTreeSet<String> = BTreeSet::new();
+    for (index, rel) in files_to_copy.iter().enumerate() {
+        let src = extracted.join(rel);
+        let dst = dest_dir.join(rel);
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(&src, &dst)?;
+        let rel_text = rel.to_string_lossy().replace('\\', "/");
+        for ancestor in rel.ancestors().skip(1) {
+            let text = ancestor.to_string_lossy().replace('\\', "/");
+            if !text.is_empty() && text != "." {
+                copied_dirs.insert(text);
+            }
+        }
+        copied_files.push(rel_text);
+        progress(index + 1, total);
+    }
+    Ok(CopiedPayload {
+        files: copied_files,
+        directories: copied_dirs.into_iter().collect(),
+    })
+}
+
+fn collect_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(root, &path, out)?;
+        } else if let Ok(rel) = path.strip_prefix(root) {
+            out.push(rel.to_path_buf());
+        }
+    }
+    Ok(())
+}
+
+/// Locate OptiScaler.dll in the extracted payload (root first, then subdirs).
+pub fn find_optiscaler_dll(extracted: &Path) -> Option<PathBuf> {
+    let direct = extracted.join("OptiScaler.dll");
+    if direct.exists() {
+        return Some(direct);
+    }
+    let mut all = Vec::new();
+    collect_files(extracted, extracted, &mut all).ok()?;
+    all.into_iter()
+        .find(|rel| {
+            rel.file_name()
+                .map(|n| n.eq_ignore_ascii_case("OptiScaler.dll"))
+                .unwrap_or(false)
+        })
+        .map(|rel| extracted.join(rel))
+}
+
+/// Interactive "Remove OptiScaler.bat" — same shape as the Python generator.
+pub fn create_uninstaller_script(
+    install_dir: &Path,
+    copied_files: &[String],
+) -> std::io::Result<()> {
+    let mut script = String::from(
+        "@echo off\ncls\necho OptiScaler Uninstaller\necho ======================\necho.\n\
+         echo This will remove OptiScaler from this game.\necho.\n\
+         set /p removeChoice=\"Do you want to remove OptiScaler? [y/n]: \"\n\
+         if \"%removeChoice%\"==\"y\" (\n    echo Removing OptiScaler files...\n",
+    );
+    for file in copied_files {
+        let win_path = file.replace('/', "\\");
+        script.push_str(&format!("    if exist \"{win_path}\" del \"{win_path}\"\n"));
+    }
+    for dir in LEGACY_UNINSTALL_DIRS {
+        script.push_str(&format!("    if exist \"{dir}\" rd /s /q \"{dir}\"\n"));
+    }
+    script.push_str(
+        "    if exist OptiScaler.log del OptiScaler.log\n    echo.\n\
+         echo OptiScaler removed successfully!\n    echo.\n) else (\n    echo.\n\
+         echo Operation cancelled.\n    echo.\n)\npause\nif \"%removeChoice%\"==\"y\" (\n    del \"%0\"\n)\n",
+    );
+    std::fs::write(install_dir.join("Remove OptiScaler.bat"), script)
+}
+
+/// Default OptiScaler.ini written when no config exists. Same content as the
+/// Python `create_default_config`.
+pub fn create_default_config(install_dir: &Path, gpu_type: &str) -> std::io::Result<()> {
+    let content = format!(
+        "[OptiScaler]\n; OptiScaler Configuration File\n; Generated by OptiScaler-GUI\n\n\
+[GPU]\n; GPU type detection - auto, nvidia, amd, intel\nGPUType={gpu_type}\n\n\
+[DLSS]\n; Enable DLSS support\nEnabled=auto\n; Path to DLSS library  \nLibraryPath=auto\n\
+; DLSS feature path\nFeaturePath=auto\n; Path to NVNGX DLSS library\nNVNGX_DLSS_Path=auto\n\n\
+[XeSS]\n; Enable Intel XeSS support\nEnabled=auto\n; XeSS library path\nLibraryPath=auto\n\
+; XeSS DirectX 11 library path\nDx11LibraryPath=auto\n\n\
+[FSR]\n; Enable AMD FSR support\nEnabled=auto\n\n\
+[Spoofing]\n; Enable DXGI spoofing for AMD/Intel GPUs\nDxgi=auto\n; Enable Streamline spoofing\nStreamline=auto\n\n\
+[Log]\n; Logging level (0=Error, 1=Warn, 2=Info, 3=Debug)\nLogLevel=2\n; Log to console\nLogToConsole=false\n\
+; Log to file\nLogToFile=true\n; Log file name\nLogFile=auto\n\n\
+[Overlay]\n; Enable performance overlay\nEnabled=true\n\n\
+[Hotkeys]\n; Key to toggle overlay (Insert key)\nToggleOverlay=VK_INSERT\n"
+    );
+    std::fs::write(install_dir.join("OptiScaler.ini"), content)
+}
+
+/// Remove files/dirs copied during a failed install (path-traversal guarded).
+pub fn rollback(install_dir: &Path, files: &[String], directories: &[String]) {
+    let root = install_dir
+        .canonicalize()
+        .unwrap_or_else(|_| install_dir.to_path_buf());
+    for rel in files {
+        let path = install_dir.join(rel);
+        if path_within(&path, &root) && path.is_file() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+    let mut dirs: Vec<&String> = directories.iter().collect();
+    dirs.sort_by_key(|d| std::cmp::Reverse(d.len()));
+    for rel in dirs {
+        let path = install_dir.join(rel);
+        if path_within(&path, &root) && path.is_dir() {
+            let _ = std::fs::remove_dir_all(path);
+        }
+    }
+}
+
+pub(crate) fn path_within(path: &Path, root: &Path) -> bool {
+    let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    resolved
+        .to_string_lossy()
+        .to_lowercase()
+        .starts_with(&root.to_string_lossy().to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::io::Write;
+
+    #[test]
+    fn install_dir_prefers_unreal_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path().join("Game");
+        fs::create_dir_all(game.join("Engine").join("Binaries").join("Win64")).unwrap();
+        assert!(determine_install_directory(&game).ends_with("Win64"));
+        let plain = tmp.path().join("Plain");
+        fs::create_dir_all(&plain).unwrap();
+        assert_eq!(determine_install_directory(&plain), plain);
+    }
+
+    #[test]
+    fn payload_copy_skips_markers_and_main_dll() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("extracted");
+        let dst = tmp.path().join("game");
+        fs::create_dir_all(src.join("Licenses")).unwrap();
+        fs::create_dir_all(&dst).unwrap();
+        for name in [
+            "OptiScaler.dll",
+            "!! README_EXTRACT ALL FILES TO GAME FOLDER !!.txt",
+            "fakenvapi.dll",
+            "OptiScaler.ini",
+        ] {
+            File::create(src.join(name)).unwrap();
+        }
+        File::create(src.join("Licenses").join("LICENSE.txt")).unwrap();
+
+        let payload = copy_release_payload(&src, &dst, |_, _| {}).unwrap();
+        assert!(payload.files.contains(&"fakenvapi.dll".to_string()));
+        assert!(payload.files.contains(&"Licenses/LICENSE.txt".to_string()));
+        assert!(!payload.files.iter().any(|f| f.contains("OptiScaler.dll")));
+        assert!(!payload.files.iter().any(|f| f.starts_with("!!")));
+        assert_eq!(payload.directories, vec!["Licenses"]);
+        assert!(dst.join("fakenvapi.dll").exists());
+        assert!(!dst.join("OptiScaler.dll").exists());
+    }
+
+    #[test]
+    fn stale_legacy_cleanup_preserves_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        File::create(tmp.path().join("nvapi64.dll")).unwrap();
+        File::create(tmp.path().join("nvngx.dll")).unwrap();
+        remove_stale_legacy_files(tmp.path(), "nvngx.dll");
+        assert!(!tmp.path().join("nvapi64.dll").exists());
+        assert!(tmp.path().join("nvngx.dll").exists()); // chosen proxy preserved
+    }
+
+    #[test]
+    fn config_backup_and_rollback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut f = File::create(tmp.path().join("OptiScaler.ini")).unwrap();
+        f.write_all(b"[X]\nk=v\n").unwrap();
+        drop(f);
+        let backup = backup_existing_config(tmp.path(), "20260712-120000").unwrap();
+        assert!(backup.exists());
+
+        File::create(tmp.path().join("some.dll")).unwrap();
+        fs::create_dir_all(tmp.path().join("Licenses")).unwrap();
+        rollback(tmp.path(), &["some.dll".into()], &["Licenses".into()]);
+        assert!(!tmp.path().join("some.dll").exists());
+        assert!(!tmp.path().join("Licenses").exists());
+        assert!(backup.exists()); // backups survive rollback
+    }
+
+    #[test]
+    fn finds_optiscaler_dll_in_subdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("nested");
+        fs::create_dir_all(&sub).unwrap();
+        File::create(sub.join("OptiScaler.dll")).unwrap();
+        let found = find_optiscaler_dll(tmp.path()).unwrap();
+        assert!(found.ends_with(Path::new("nested").join("OptiScaler.dll")));
+    }
+}

--- a/rust/crates/opticore/src/lib.rs
+++ b/rust/crates/opticore/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod appids;
 pub mod archive;
 pub mod images;
+pub mod install;
 pub mod model;
 pub mod progress;
 pub mod scan;

--- a/rust/crates/opticore/src/progress.rs
+++ b/rust/crates/opticore/src/progress.rs
@@ -19,6 +19,16 @@ pub enum TaskEvent {
     ImageMissing { path_norm: String },
     /// The SteamSpy catalogue finished loading — retry missing artwork.
     AppListReady,
+    /// Install/update/uninstall progress for one game.
+    OpProgress { path_norm: String, label: String },
+    /// Install/update/uninstall finished for one game.
+    OpFinished {
+        path_norm: String,
+        ok: bool,
+        message: String,
+    },
+    /// Latest OptiScaler release tag (for update badges).
+    LatestRelease { version: String },
     /// A log line for the log screen.
     Log(String),
 }

--- a/rust/crates/opticore/tests/fixtures/python_manifest.json
+++ b/rust/crates/opticore/tests/fixtures/python_manifest.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "installed_by": "OptiScaler-GUI",
+  "installed_at": "2026-07-12T18:31:52.162486",
+  "target_filename": "dxgi.dll",
+  "optiscaler_version": "v0.9.3",
+  "release_url": "https://github.com/optiscaler/OptiScaler/releases/tag/v0.9.3",
+  "files": [
+    "D3D12_Optiscaler/plugin.dll",
+    "OptiScaler.ini",
+    "Remove OptiScaler.bat",
+    "dxgi.dll",
+    "fakenvapi.dll"
+  ],
+  "directories": [
+    "D3D12_Optiscaler",
+    "Licenses"
+  ]
+}

--- a/rust/crates/optiscaler-gui/src/app.rs
+++ b/rust/crates/optiscaler-gui/src/app.rs
@@ -52,6 +52,45 @@ impl App {
                     self.state
                         .push_log("App list ready — retrying missing artwork".into());
                 }
+                TaskEvent::OpProgress { path_norm, label } => {
+                    self.state.busy_ops.insert(path_norm, label);
+                }
+                TaskEvent::OpFinished {
+                    path_norm,
+                    ok,
+                    message,
+                } => {
+                    self.state.busy_ops.remove(&path_norm);
+                    self.state.push_log(format!(
+                        "{}: {}",
+                        if ok { "Done" } else { "Failed" },
+                        message
+                    ));
+                    self.state
+                        .op_results
+                        .insert(path_norm.clone(), (ok, message));
+                    if ok {
+                        // Refresh install state for the affected game
+                        if let Some(game) = self
+                            .state
+                            .games
+                            .iter_mut()
+                            .find(|g| g.key.path_norm == path_norm)
+                        {
+                            if let Some(facts) = opticore::scan::folder_facts::collect(&game.path) {
+                                game.optiscaler_installed =
+                                    opticore::scan::folder_facts::detect_optiscaler(
+                                        &game.path, &facts,
+                                    );
+                            }
+                        }
+                    }
+                }
+                TaskEvent::LatestRelease { version } => {
+                    self.state
+                        .push_log(format!("Latest OptiScaler release: {version}"));
+                    self.state.latest_release = Some(version);
+                }
                 TaskEvent::Log(line) => self.state.push_log(line),
             }
         }
@@ -108,6 +147,7 @@ impl eframe::App for App {
         if !self.started {
             self.started = true;
             self.ops.spawn_catalogue_load(ctx);
+            self.ops.spawn_release_check(ctx);
             self.state.scan_state = ScanState::Running;
             self.ops.spawn_scan(ctx);
         }

--- a/rust/crates/optiscaler-gui/src/ops.rs
+++ b/rust/crates/optiscaler-gui/src/ops.rs
@@ -4,6 +4,7 @@
 use eframe::egui;
 use opticore::appids::AppIdResolver;
 use opticore::images::ImageCache;
+use opticore::install::{self, InstallOptions, InstallStage, Installer};
 use opticore::model::Game;
 use opticore::progress::TaskEvent;
 use opticore::scan::{scan_all, ScanConfig};
@@ -118,5 +119,101 @@ impl Ops {
     /// Allow re-requesting images (after AppListReady retry-reset).
     pub fn clear_inflight(&mut self) {
         self.inflight_images.clear();
+    }
+
+    fn downloads_dir(&self) -> PathBuf {
+        // sibling of cache/game_images → cache/optiscaler_downloads (Python layout)
+        let base = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+            .unwrap_or_else(|| PathBuf::from("."));
+        base.join("cache").join("optiscaler_downloads")
+    }
+
+    /// Check the latest OptiScaler release for update badges.
+    pub fn spawn_release_check(&self, ctx: &egui::Context) {
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        std::thread::spawn(move || {
+            if let Ok(release) = install::github::fetch_latest_release() {
+                let _ = tx.send(TaskEvent::LatestRelease {
+                    version: release.version_label(),
+                });
+                ctx.request_repaint();
+            }
+        });
+    }
+
+    fn stage_label(stage: &InstallStage) -> String {
+        match stage {
+            InstallStage::FetchingRelease => "Fetching release…".into(),
+            InstallStage::Downloading { done, total } if *total > 0 => {
+                format!("Downloading… {}%", done * 100 / total)
+            }
+            InstallStage::Downloading { .. } => "Downloading…".into(),
+            InstallStage::Extracting => "Extracting…".into(),
+            InstallStage::CopyingPayload { done, total } => {
+                format!("Installing files… {done}/{total}")
+            }
+            InstallStage::Finalizing => "Finalizing…".into(),
+        }
+    }
+
+    /// Install or update OptiScaler for one game on a worker thread.
+    pub fn spawn_install(&self, ctx: &egui::Context, game: &Game, options: InstallOptions) {
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        let key = game.key.path_norm.clone();
+        let game_path = game.path.clone();
+        let downloads = self.downloads_dir();
+        std::thread::spawn(move || {
+            let installer = Installer::new(&downloads);
+            let progress_tx = tx.clone();
+            let progress_ctx = ctx.clone();
+            let progress_key = key.clone();
+            let result = installer.install(&game_path, &options, move |stage| {
+                let _ = progress_tx.send(TaskEvent::OpProgress {
+                    path_norm: progress_key.clone(),
+                    label: Self::stage_label(&stage),
+                });
+                progress_ctx.request_repaint();
+            });
+            let (ok, message) = match result {
+                Ok(m) => (
+                    true,
+                    format!("Installed OptiScaler {}", m.optiscaler_version),
+                ),
+                Err(e) => (false, e.to_string()),
+            };
+            let _ = tx.send(TaskEvent::OpFinished {
+                path_norm: key,
+                ok,
+                message,
+            });
+            ctx.request_repaint();
+        });
+    }
+
+    /// Uninstall OptiScaler from one game on a worker thread.
+    pub fn spawn_uninstall(&self, ctx: &egui::Context, game: &Game) {
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        let key = game.key.path_norm.clone();
+        let game_path = game.path.clone();
+        std::thread::spawn(move || {
+            let (ok, message) = match install::uninstall(&game_path) {
+                Ok((files, dirs)) => (
+                    true,
+                    format!("Removed {} files, {} directories", files.len(), dirs.len()),
+                ),
+                Err(e) => (false, e.to_string()),
+            };
+            let _ = tx.send(TaskEvent::OpFinished {
+                path_norm: key,
+                ok,
+                message,
+            });
+            ctx.request_repaint();
+        });
     }
 }

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -34,7 +34,7 @@ pub fn show(ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
         if let Some(game) = game {
             egui::SidePanel::right("game_detail")
                 .default_width(300.0)
-                .show(ctx, |ui| detail_panel(ui, ctx, state, &game));
+                .show(ctx, |ui| detail_panel(ui, ctx, state, ops, &game));
         } else {
             state.selected = None;
         }
@@ -305,7 +305,13 @@ fn badge(ui: &egui::Ui, pos: egui::Pos2, text: &str, color: Color32) -> egui::Po
     egui::pos2(rect.max.x + 6.0, pos.y)
 }
 
-fn detail_panel(ui: &mut egui::Ui, ctx: &egui::Context, state: &mut AppState, game: &Game) {
+fn detail_panel(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    state: &mut AppState,
+    ops: &mut Ops,
+    game: &Game,
+) {
     ui.add_space(6.0);
     ui.horizontal(|ui| {
         ui.heading(&game.name);
@@ -349,14 +355,6 @@ fn detail_panel(ui: &mut egui::Ui, ctx: &egui::Context, state: &mut AppState, ga
             ui.end_row();
         });
 
-    if !game.anti_cheat.is_empty() {
-        ui.add_space(6.0);
-        ui.colored_label(
-            theme::BADGE_WARN,
-            format!("⚠ Anti-cheat detected: {:?}", game.anti_cheat),
-        );
-    }
-
     ui.add_space(8.0);
     ui.label(
         RichText::new(game.path.display().to_string())
@@ -364,14 +362,146 @@ fn detail_panel(ui: &mut egui::Ui, ctx: &egui::Context, state: &mut AppState, ga
             .color(theme::TEXT_DIM),
     );
     ui.add_space(8.0);
+    ui.separator();
 
-    ui.horizontal(|ui| {
-        if ui.button("📂 Open folder").clicked() {
-            let _ = std::process::Command::new("explorer")
-                .arg(&game.path)
-                .spawn();
+    install_section(ui, ctx, state, ops, game);
+
+    ui.add_space(8.0);
+    if ui.button("📂 Open folder").clicked() {
+        let _ = std::process::Command::new("explorer")
+            .arg(&game.path)
+            .spawn();
+    }
+}
+
+/// Install / Update / Uninstall actions with anti-cheat confirmation and
+/// per-game progress.
+fn install_section(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    state: &mut AppState,
+    ops: &mut Ops,
+    game: &Game,
+) {
+    // Operation in flight → progress only
+    if let Some(label) = state.busy_ops.get(&game.key.path_norm) {
+        ui.horizontal(|ui| {
+            ui.spinner();
+            ui.label(label.clone());
+        });
+        return;
+    }
+
+    // Last operation result
+    if let Some((ok, message)) = state.op_results.get(&game.key.path_norm) {
+        let color = if *ok {
+            theme::BADGE_OK
+        } else {
+            theme::BADGE_DANGER
+        };
+        ui.colored_label(color, message.clone());
+        ui.add_space(4.0);
+    }
+
+    // Anti-cheat warning requires explicit confirmation before install/update
+    let needs_confirm = !game.anti_cheat.is_empty();
+    if needs_confirm {
+        ui.colored_label(
+            theme::BADGE_WARN,
+            format!(
+                "⚠ Anti-cheat detected ({}). Installing mods into online games can trigger bans.",
+                game.anti_cheat
+                    .iter()
+                    .map(|ac| format!("{ac:?}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        );
+        ui.checkbox(
+            &mut state.anticheat_confirmed,
+            "I understand the risk — continue anyway",
+        );
+        ui.add_space(4.0);
+    }
+    let allowed = !needs_confirm || state.anticheat_confirmed;
+
+    if game.optiscaler_installed {
+        // Update path: compare installed manifest version vs latest release
+        let installed = opticore::install::installed_version(&game.path);
+        if let (Some(installed), Some(latest)) =
+            (installed.as_deref(), state.latest_release.as_deref())
+        {
+            if opticore::install::is_update_available(installed, latest) {
+                ui.colored_label(
+                    theme::ACCENT,
+                    format!("Update available: {installed} → {latest}"),
+                );
+                if ui
+                    .add_enabled(
+                        allowed,
+                        egui::Button::new(RichText::new("⬆ Update OptiScaler").strong()),
+                    )
+                    .clicked()
+                {
+                    let target = opticore::install::installed_target_filename(&game.path)
+                        .unwrap_or_else(|| "dxgi.dll".to_string());
+                    let options = opticore::install::InstallOptions {
+                        target_filename: target,
+                        overwrite: true,
+                        ..Default::default()
+                    };
+                    state
+                        .busy_ops
+                        .insert(game.key.path_norm.clone(), "Starting update…".into());
+                    ops.spawn_install(ctx, game, options);
+                }
+                ui.add_space(4.0);
+            } else {
+                ui.label(
+                    RichText::new(format!("Installed: {installed} (up to date)"))
+                        .color(theme::TEXT_DIM),
+                );
+            }
+        } else if let Some(installed) = installed {
+            ui.label(RichText::new(format!("Installed: {installed}")).color(theme::TEXT_DIM));
         }
-        ui.add_enabled(false, egui::Button::new("Install OptiScaler"))
-            .on_disabled_hover_text("Coming in M3");
-    });
+
+        if ui
+            .add_enabled(allowed, egui::Button::new("🗑 Uninstall OptiScaler"))
+            .clicked()
+        {
+            state
+                .busy_ops
+                .insert(game.key.path_norm.clone(), "Uninstalling…".into());
+            ops.spawn_uninstall(ctx, game);
+        }
+    } else {
+        ui.horizontal(|ui| {
+            ui.label(RichText::new("Install as").color(theme::TEXT_DIM));
+            egui::ComboBox::from_id_salt("proxy_choice")
+                .selected_text(state.proxy_choice.clone())
+                .show_ui(ui, |ui| {
+                    for name in opticore::install::payload::PROXY_FILENAMES {
+                        ui.selectable_value(&mut state.proxy_choice, name.to_string(), *name);
+                    }
+                });
+        });
+        if ui
+            .add_enabled(
+                allowed,
+                egui::Button::new(RichText::new("⬇ Install OptiScaler").strong()),
+            )
+            .clicked()
+        {
+            let options = opticore::install::InstallOptions {
+                target_filename: state.proxy_choice.clone(),
+                overwrite: false,
+                ..Default::default()
+            };
+            state
+                .busy_ops
+                .insert(game.key.path_norm.clone(), "Starting install…".into());
+            ops.spawn_install(ctx, game, options);
+        }
+    }
 }

--- a/rust/crates/optiscaler-gui/src/state.rs
+++ b/rust/crates/optiscaler-gui/src/state.rs
@@ -41,6 +41,16 @@ pub struct AppState {
     pub selected: Option<String>, // path_norm of selected game
     pub art: HashMap<String, ArtState>,
     pub log: VecDeque<String>,
+    /// Latest OptiScaler release tag (for update badges), once checked.
+    pub latest_release: Option<String>,
+    /// Games with an install/uninstall running: path_norm → progress label.
+    pub busy_ops: HashMap<String, String>,
+    /// Last finished operation result per game: (ok, message).
+    pub op_results: HashMap<String, (bool, String)>,
+    /// Anti-cheat confirmation checkbox state in the detail panel.
+    pub anticheat_confirmed: bool,
+    /// Selected proxy filename in the install flow.
+    pub proxy_choice: String,
     textures: HashMap<String, TextureHandle>,
     texture_lru: VecDeque<String>,
 }
@@ -56,6 +66,11 @@ impl Default for AppState {
             selected: None,
             art: HashMap::new(),
             log: VecDeque::new(),
+            latest_release: None,
+            busy_ops: HashMap::new(),
+            op_results: HashMap::new(),
+            anticheat_confirmed: false,
+            proxy_choice: "dxgi.dll".to_string(),
             textures: HashMap::new(),
             texture_lru: VecDeque::new(),
         }


### PR DESCRIPTION
Fourth milestone: the app''s core job. Download, verify, extract, install, update, and uninstall — all ported, all verified against the real v0.9.3 release, and **provably compatible with installs made by the Python app**.

## The cross-version contract, proven
The install manifest (`.optiscaler-gui-install.json`, schema v1) is the bridge between the two apps:
- **Rust install → Python uninstall:** Rust installed the real release into a test game folder (21 files, SHA256-verified download, pure-Rust BCJ2 extraction). The *actual Python app* then read the Rust-written manifest and uninstalled cleanly — zero OptiScaler leftovers, game files untouched.
- The Rust reader is tested against a manifest fixture generated by the real Python `_write_install_manifest`.

## Update flow (user-requested)
- Release check on startup → detail panel shows **"Update available: v0.9.2 → v0.9.3"** with an Update button when the installed manifest version is older
- Update reuses the **recorded proxy filename** (verified: an install as `winmm.dll` updated as `winmm.dll` — no stray `dxgi.dll`), backs up a user-modified `OptiScaler.ini` with a timestamp (customization confirmed present in the backup), cleans stale legacy files, writes a fresh manifest

## What''s in it
- `install/github.rs` — releases/latest, asset pick, streaming download + SHA256 digest verify, digest-valid cache reuse
- `install/payload.rs` — markers, stale-legacy cleanup, config backup, dynamic payload copy, uninstaller .bat, default config, rollback (path-traversal guarded)
- `install/mod.rs` — install/update orchestration (Unreal `Engine/Binaries/Win64` rule, v0.7.9 DLSS-inputs semantics), manifest-based uninstall + legacy fallback, version comparison
- GUI detail panel: Install (proxy combo), Update (badge + button), Uninstall, per-game live progress, result banners, **anti-cheat risk confirmation** gating install/update

## Verification
Real-release round-trips on the dev machine (install → Python-uninstall; install-as-winmm → downgrade → update → uninstall), 52 opticore tests, clippy `-D warnings` clean, release exe 6.75 MB.

Fun Windows fact: the dev CLI had to be renamed from `install_cli` to `manage_cli` — Windows requires elevation for any exe with "install" in its name.

Next: **M4 — INI settings editor + GPU auto-recommendations.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)