### PR TITLE
Rust rewrite M4: OptiScaler.ini editor with 287/287 parse parity + GPU Auto Settings

### DIFF
--- a/rust/crates/opticore/examples/ini_dump.rs
+++ b/rust/crates/opticore/examples/ini_dump.rs
@@ -1,0 +1,28 @@
+//! Dev harness: dump a parsed OptiScaler.ini as section|key|type|value lines
+//! for parity diffing against the Python reader.
+
+use opticore::ini::{read_file, ValueKind};
+use std::path::Path;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("ini path argument");
+    let doc = read_file(Path::new(&path)).expect("readable ini");
+    let mut lines: Vec<String> = Vec::new();
+    for section in &doc.sections {
+        for entry in &section.entries {
+            let kind = match &entry.kind {
+                ValueKind::BoolOptions => "bool_options",
+                ValueKind::Options(_) => "options",
+                ValueKind::Int => "int",
+                ValueKind::Float => "float",
+                ValueKind::Text => "string",
+            };
+            lines.push(format!(
+                "{}|{}|{}|{}",
+                section.name, entry.key, kind, entry.value
+            ));
+        }
+    }
+    lines.sort();
+    println!("{}", lines.join("\n"));
+}

--- a/rust/crates/opticore/src/ini.rs
+++ b/rust/crates/opticore/src/ini.rs
@@ -1,0 +1,421 @@
+//! OptiScaler.ini parsing/serialization with the Python app's semantics:
+//! comments accumulate until the next key and drive type inference; writing
+//! preserves section order, per-key comments, and creates an .ini.backup.
+//! Port of `read_optiscaler_ini` / `write_optiscaler_ini` / `_infer_type`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Inferred kind of a setting value, driving the editor widget choice.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValueKind {
+    /// true / false / auto
+    BoolOptions,
+    /// Enumerated options from a "0 = A | 1 = B" comment: raw → display label
+    Options(BTreeMap<String, String>),
+    Int,
+    Float,
+    Text,
+}
+
+#[derive(Debug, Clone)]
+pub struct Entry {
+    pub key: String,
+    pub value: String,
+    pub comment: String,
+    pub kind: ValueKind,
+}
+
+#[derive(Debug, Clone)]
+pub struct Section {
+    pub name: String,
+    pub entries: Vec<Entry>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct IniDocument {
+    pub sections: Vec<Section>,
+}
+
+impl IniDocument {
+    pub fn get(&self, section: &str, key: &str) -> Option<&Entry> {
+        self.sections
+            .iter()
+            .find(|s| s.name.eq_ignore_ascii_case(section))?
+            .entries
+            .iter()
+            .find(|e| e.key.eq_ignore_ascii_case(key))
+    }
+
+    pub fn set_value(&mut self, section: &str, key: &str, value: &str) -> bool {
+        if let Some(entry) = self
+            .sections
+            .iter_mut()
+            .find(|s| s.name.eq_ignore_ascii_case(section))
+            .and_then(|s| {
+                s.entries
+                    .iter_mut()
+                    .find(|e| e.key.eq_ignore_ascii_case(key))
+            })
+        {
+            entry.value = value.to_string();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Port of `_infer_type`: comment text drives bool/enum detection, then
+/// int/float probes, else free text.
+pub fn infer_kind(value: &str, comment: &str) -> ValueKind {
+    let comment_lower = comment.to_lowercase();
+    let value_lower = value.to_lowercase();
+    if comment_lower.contains("true or false")
+        || (["true", "false", "auto"].contains(&value_lower.as_str())
+            && comment_lower.contains("auto"))
+    {
+        return ValueKind::BoolOptions;
+    }
+
+    // "0 = Option A | 1 = Option B" enumerations in the comment
+    if let Some(options) = parse_options(comment) {
+        let mut options = options;
+        if value_lower.contains("auto") || comment_lower.contains("default (auto)") {
+            let has_auto = options.values().any(|v| v == "auto");
+            if !has_auto {
+                options.insert("auto".to_string(), "auto".to_string());
+            }
+        }
+        return ValueKind::Options(options);
+    }
+
+    if value.parse::<i64>().is_ok() {
+        return ValueKind::Int;
+    }
+    if value.parse::<f64>().is_ok() {
+        return ValueKind::Float;
+    }
+    ValueKind::Text
+}
+
+/// Find a `<digits> = label (| <digits> = label)*` run inside the comment.
+fn parse_options(comment: &str) -> Option<BTreeMap<String, String>> {
+    // locate the first "<digits> <spaces>? = " occurrence
+    let bytes: Vec<char> = comment.chars().collect();
+    let mut start = None;
+    for i in 0..bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                j += 1;
+            }
+            let mut k = j;
+            while k < bytes.len() && bytes[k] == ' ' {
+                k += 1;
+            }
+            if k < bytes.len() && bytes[k] == '=' {
+                start = Some(i);
+                break;
+            }
+        }
+    }
+    let start = start?;
+    let candidate: String = bytes[start..].iter().collect();
+    // cut at end of line — options runs don't span comment lines
+    let candidate = candidate.lines().next().unwrap_or("");
+    let mut options = BTreeMap::new();
+    for item in candidate.split('|') {
+        if let Some((k, v)) = item.split_once('=') {
+            let key = k.trim();
+            let value = v.trim();
+            if !key.is_empty() && key.chars().all(|c| c.is_ascii_digit()) && !value.is_empty() {
+                options.insert(key.to_string(), value.to_string());
+            }
+        }
+    }
+    if options.is_empty() {
+        None
+    } else {
+        Some(options)
+    }
+}
+
+/// Parse an OptiScaler.ini. Same rules as the Python reader: blank lines
+/// skipped, `; comments` accumulate until the next key, inline comments
+/// stripped from values.
+pub fn parse(content: &str) -> IniDocument {
+    let mut doc = IniDocument::default();
+    let mut current_comments: Vec<String> = Vec::new();
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('[') {
+            if let Some(name) = rest.strip_suffix(']') {
+                doc.sections.push(Section {
+                    name: name.trim().to_string(),
+                    entries: Vec::new(),
+                });
+                current_comments.clear();
+            }
+        } else if let Some(comment) = line.strip_prefix(';') {
+            current_comments.push(comment.trim().to_string());
+        } else if let Some((key, value)) = line.split_once('=') {
+            let Some(section) = doc.sections.last_mut() else {
+                continue; // key-value outside any section
+            };
+            let value = value.split(';').next().unwrap_or("").trim().to_string();
+            let comment = current_comments.join("\n");
+            let kind = infer_kind(&value, &comment);
+            section.entries.push(Entry {
+                key: key.trim().to_string(),
+                value,
+                comment,
+                kind,
+            });
+            current_comments.clear();
+        }
+    }
+    doc
+}
+
+pub fn read_file(ini_path: &Path) -> Option<IniDocument> {
+    let content = std::fs::read_to_string(ini_path).ok()?;
+    Some(parse(&content))
+}
+
+/// Serialize back to INI text (sections, `; comment` lines, key=value).
+pub fn serialize(doc: &IniDocument) -> String {
+    let mut out = String::new();
+    for section in &doc.sections {
+        out.push_str(&format!("[{}]\n", section.name));
+        for entry in &section.entries {
+            for comment_line in entry.comment.split('\n') {
+                if !comment_line.trim().is_empty() {
+                    out.push_str(&format!("; {comment_line}\n"));
+                }
+            }
+            out.push_str(&format!("{}={}\n", entry.key, entry.value));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Write with a `.ini.backup` copy of the previous file, like Python.
+pub fn write_file(ini_path: &Path, doc: &IniDocument) -> std::io::Result<()> {
+    if let Some(parent) = ini_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if ini_path.exists() {
+        let backup = ini_path.with_extension("ini.backup");
+        std::fs::copy(ini_path, backup)?;
+    }
+    std::fs::write(ini_path, serialize(doc))
+}
+
+/// GPU-vendor-based recommended settings, applied only where the key exists
+/// in the document. Port of the settings editor's Auto Settings table.
+pub fn auto_settings(vendor: GpuVendor) -> Vec<(&'static str, &'static str, &'static str)> {
+    // (section, key, value)
+    let mut settings: Vec<(&str, &str, &str)> = match vendor {
+        GpuVendor::Nvidia => vec![
+            ("Dlss", "Enabled", "true"),
+            ("Dlss", "QualityMode", "2"),
+            ("Fsr", "Enabled", "auto"),
+            ("Fsr", "QualityMode", "2"),
+            ("Xess", "Enabled", "auto"),
+        ],
+        GpuVendor::Amd => vec![
+            ("Fsr", "Enabled", "true"),
+            ("Fsr", "QualityMode", "2"),
+            ("Fsr", "Sharpness", "0.5"),
+            ("Dlss", "Enabled", "false"),
+            ("Xess", "Enabled", "auto"),
+            ("Xess", "QualityMode", "2"),
+        ],
+        GpuVendor::Intel => vec![
+            ("Xess", "Enabled", "true"),
+            ("Xess", "QualityMode", "2"),
+            ("Fsr", "Enabled", "auto"),
+            ("Fsr", "QualityMode", "2"),
+            ("Dlss", "Enabled", "false"),
+        ],
+        GpuVendor::Unknown => vec![
+            ("Fsr", "Enabled", "true"),
+            ("Fsr", "QualityMode", "3"),
+            ("Dlss", "Enabled", "false"),
+            ("Xess", "Enabled", "false"),
+        ],
+    };
+    settings.extend([
+        ("Performance", "EnableAsyncCompute", "true"),
+        ("Performance", "EnableFP16", "true"),
+        ("Performance", "AutoExposure", "true"),
+        ("Output", "DisplayResolution", "auto"),
+        ("Output", "RenderingResolution", "auto"),
+        ("Advanced", "MotionVectors", "true"),
+        ("Advanced", "ExposureScale", "1.0"),
+        ("Advanced", "AutoBias", "true"),
+        (
+            "GPU",
+            "GPUType",
+            match vendor {
+                GpuVendor::Nvidia => "nvidia",
+                GpuVendor::Amd => "amd",
+                GpuVendor::Intel => "intel",
+                GpuVendor::Unknown => "auto",
+            },
+        ),
+    ]);
+    settings
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuVendor {
+    Nvidia,
+    Amd,
+    Intel,
+    Unknown,
+}
+
+impl GpuVendor {
+    /// Map a PCI vendor id (e.g. from wgpu AdapterInfo) to a vendor.
+    pub fn from_pci_vendor_id(id: u32) -> Self {
+        match id {
+            0x10DE => GpuVendor::Nvidia,
+            0x1002 => GpuVendor::Amd,
+            0x8086 => GpuVendor::Intel,
+            _ => GpuVendor::Unknown,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            GpuVendor::Nvidia => "NVIDIA",
+            GpuVendor::Amd => "AMD",
+            GpuVendor::Intel => "Intel",
+            GpuVendor::Unknown => "Unknown",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"[Upscalers]
+; Select upscaler for Dx12 games
+; 0 = FSR2 | 1 = FSR3 | 2 = XeSS
+Dx12Upscaler=1
+
+[Sharpness]
+; true or false - enable sharpening
+OverrideSharpness=auto
+; Sharpness value between 0.0 and 1.0
+Sharpness=0.5
+
+[Log]
+LogLevel=2
+LogFile=auto ; inline comment here
+"#;
+
+    #[test]
+    fn parses_sections_and_kinds() {
+        let doc = parse(SAMPLE);
+        assert_eq!(doc.sections.len(), 3);
+
+        let upscaler = doc.get("Upscalers", "Dx12Upscaler").unwrap();
+        match &upscaler.kind {
+            ValueKind::Options(opts) => {
+                assert_eq!(opts.get("0").map(String::as_str), Some("FSR2"));
+                assert_eq!(opts.get("2").map(String::as_str), Some("XeSS"));
+            }
+            other => panic!("expected options, got {other:?}"),
+        }
+
+        // Python parity: value "auto" + "auto" anywhere in the comment wins
+        // as BoolOptions even when an options run is present
+        assert_eq!(
+            infer_kind("auto", "0 = FSR2 | 1 = FSR3\nDefault (auto) is FSR3"),
+            ValueKind::BoolOptions
+        );
+        // …but a numeric value with "default (auto)" gets auto injected into
+        // the enum options
+        match infer_kind("1", "0 = FSR2 | 1 = FSR3\nDefault (auto) is FSR3") {
+            ValueKind::Options(opts) => {
+                assert_eq!(opts.get("auto").map(String::as_str), Some("auto"));
+            }
+            other => panic!("expected options with auto, got {other:?}"),
+        }
+
+        let sharp_toggle = doc.get("Sharpness", "OverrideSharpness").unwrap();
+        assert_eq!(sharp_toggle.kind, ValueKind::BoolOptions);
+
+        let sharpness = doc.get("Sharpness", "Sharpness").unwrap();
+        assert_eq!(sharpness.kind, ValueKind::Float);
+
+        let level = doc.get("Log", "LogLevel").unwrap();
+        assert_eq!(level.kind, ValueKind::Int);
+
+        // inline comment stripped
+        assert_eq!(doc.get("Log", "LogFile").unwrap().value, "auto");
+    }
+
+    #[test]
+    fn roundtrip_preserves_comments_and_values() {
+        let doc = parse(SAMPLE);
+        let text = serialize(&doc);
+        assert!(text.contains("; Select upscaler for Dx12 games"));
+        assert!(text.contains("; 0 = FSR2 | 1 = FSR3 | 2 = XeSS"));
+        assert!(text.contains("Dx12Upscaler=1"));
+        // reparse gives identical structure
+        let doc2 = parse(&text);
+        assert_eq!(doc2.sections.len(), doc.sections.len());
+        assert_eq!(
+            doc2.get("Sharpness", "Sharpness").unwrap().value,
+            doc.get("Sharpness", "Sharpness").unwrap().value
+        );
+    }
+
+    #[test]
+    fn write_creates_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ini = tmp.path().join("OptiScaler.ini");
+        std::fs::write(&ini, SAMPLE).unwrap();
+        let mut doc = read_file(&ini).unwrap();
+        assert!(doc.set_value("Sharpness", "Sharpness", "0.8"));
+        write_file(&ini, &doc).unwrap();
+        assert!(tmp.path().join("OptiScaler.ini.backup").exists());
+        let back = read_file(&ini).unwrap();
+        assert_eq!(back.get("Sharpness", "Sharpness").unwrap().value, "0.8");
+        // backup holds the OLD value
+        let backup = std::fs::read_to_string(tmp.path().join("OptiScaler.ini.backup")).unwrap();
+        assert!(backup.contains("Sharpness=0.5"));
+    }
+
+    #[test]
+    fn auto_settings_apply_only_where_keys_exist() {
+        let mut doc = parse("[Fsr]\nEnabled=auto\n\n[GPU]\nGPUType=auto\n");
+        let mut applied = 0;
+        for (section, key, value) in auto_settings(GpuVendor::Amd) {
+            if doc.set_value(section, key, value) {
+                applied += 1;
+            }
+        }
+        assert_eq!(applied, 2); // Fsr.Enabled + GPU.GPUType — nothing invented
+        assert_eq!(doc.get("Fsr", "Enabled").unwrap().value, "true");
+        assert_eq!(doc.get("GPU", "GPUType").unwrap().value, "amd");
+    }
+
+    #[test]
+    fn vendor_from_pci_id() {
+        assert_eq!(GpuVendor::from_pci_vendor_id(0x10DE), GpuVendor::Nvidia);
+        assert_eq!(GpuVendor::from_pci_vendor_id(0x1002), GpuVendor::Amd);
+        assert_eq!(GpuVendor::from_pci_vendor_id(0x8086), GpuVendor::Intel);
+        assert_eq!(GpuVendor::from_pci_vendor_id(0x1234), GpuVendor::Unknown);
+    }
+}

--- a/rust/crates/opticore/src/lib.rs
+++ b/rust/crates/opticore/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod appids;
 pub mod archive;
 pub mod images;
+pub mod ini;
 pub mod install;
 pub mod model;
 pub mod progress;

--- a/rust/crates/optiscaler-gui/src/app.rs
+++ b/rust/crates/optiscaler-gui/src/app.rs
@@ -16,8 +16,15 @@ pub struct App {
 impl App {
     pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
         theme::apply(&cc.egui_ctx);
+        let mut state = AppState::default();
+        // GPU vendor from the running wgpu adapter (for Auto Settings) —
+        // no WMI/PowerShell needed
+        if let Some(render_state) = cc.wgpu_render_state.as_ref() {
+            let info = render_state.adapter.get_info();
+            state.gpu_vendor = opticore::ini::GpuVendor::from_pci_vendor_id(info.vendor);
+        }
         Self {
-            state: AppState::default(),
+            state,
             ops: Ops::new(),
             started: false,
         }
@@ -155,6 +162,7 @@ impl eframe::App for App {
         self.sidebar(ctx);
         match self.state.screen {
             Screen::Games => screens::games_grid::show(ctx, &mut self.state, &mut self.ops),
+            Screen::IniEditor => screens::ini_editor::show(ctx, &mut self.state),
             Screen::Settings => screens::show_settings(ctx, &mut self.state),
             Screen::Log => screens::show_log(ctx, &mut self.state),
             Screen::About => screens::show_about(ctx, &mut self.state),

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -466,15 +466,20 @@ fn install_section(
             ui.label(RichText::new(format!("Installed: {installed}")).color(theme::TEXT_DIM));
         }
 
-        if ui
-            .add_enabled(allowed, egui::Button::new("🗑 Uninstall OptiScaler"))
-            .clicked()
-        {
-            state
-                .busy_ops
-                .insert(game.key.path_norm.clone(), "Uninstalling…".into());
-            ops.spawn_uninstall(ctx, game);
-        }
+        ui.horizontal(|ui| {
+            if ui.button("⚙ Edit settings").clicked() {
+                state.open_editor(game);
+            }
+            if ui
+                .add_enabled(allowed, egui::Button::new("🗑 Uninstall OptiScaler"))
+                .clicked()
+            {
+                state
+                    .busy_ops
+                    .insert(game.key.path_norm.clone(), "Uninstalling…".into());
+                ops.spawn_uninstall(ctx, game);
+            }
+        });
     } else {
         ui.horizontal(|ui| {
             ui.label(RichText::new("Install as").color(theme::TEXT_DIM));

--- a/rust/crates/optiscaler-gui/src/screens/ini_editor.rs
+++ b/rust/crates/optiscaler-gui/src/screens/ini_editor.rs
@@ -1,0 +1,220 @@
+//! OptiScaler.ini editor: sections as collapsing headers, widgets chosen by
+//! inferred value kind, key search, dirty-state guard, GPU Auto Settings.
+
+use crate::state::{AppState, Screen};
+use crate::theme;
+use eframe::egui::{self, Align, Layout, RichText};
+use opticore::ini::{auto_settings, ValueKind};
+
+pub fn show(ctx: &egui::Context, state: &mut AppState) {
+    let gpu_vendor = state.gpu_vendor;
+    // Take ownership for the frame so the closure doesn't borrow `state`
+    let Some(mut editor) = state.editor.take() else {
+        state.screen = Screen::Games;
+        return;
+    };
+    let mut close = false;
+
+    egui::CentralPanel::default().show(ctx, |ui| {
+        let editor = &mut editor;
+        // Header row
+        ui.horizontal(|ui| {
+            let back_label = if editor.discard_armed {
+                "← Discard changes?"
+            } else {
+                "← Back"
+            };
+            if ui.button(back_label).clicked() {
+                if editor.dirty && !editor.discard_armed {
+                    editor.discard_armed = true;
+                } else {
+                    close = true;
+                }
+            }
+            if editor.discard_armed {
+                ui.label(
+                    RichText::new("Unsaved changes — click Back again to discard")
+                        .color(theme::BADGE_WARN),
+                );
+            }
+            ui.heading(format!("Settings — {}", editor.game_name));
+        });
+        if close {
+            return;
+        }
+
+        ui.add_space(4.0);
+        ui.horizontal(|ui| {
+            ui.add(
+                egui::TextEdit::singleline(&mut editor.search)
+                    .hint_text("Search settings…")
+                    .desired_width(220.0),
+            );
+            if ui
+                .button(format!("✨ Auto Settings ({})", gpu_vendor.label()))
+                .clicked()
+            {
+                let mut applied = 0;
+                for (section, key, value) in auto_settings(gpu_vendor) {
+                    if editor.doc.set_value(section, key, value) {
+                        applied += 1;
+                    }
+                }
+                editor.dirty = applied > 0;
+                editor.status = Some(format!(
+                    "Applied {applied} recommended settings for {} — review and Save",
+                    gpu_vendor.label()
+                ));
+            }
+            let save = egui::Button::new(RichText::new("💾 Save").strong());
+            if ui.add_enabled(editor.dirty, save).clicked() {
+                match opticore::ini::write_file(&editor.ini_path, &editor.doc) {
+                    Ok(()) => {
+                        editor.dirty = false;
+                        editor.discard_armed = false;
+                        editor.status = Some("Saved (previous file kept as .ini.backup)".into());
+                    }
+                    Err(e) => editor.status = Some(format!("Save failed: {e}")),
+                }
+            }
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                if let Some(status) = &editor.status {
+                    ui.label(RichText::new(status).color(theme::TEXT_DIM));
+                }
+            });
+        });
+        ui.add_space(6.0);
+
+        let needle = editor.search.to_lowercase();
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                for section_idx in 0..editor.doc.sections.len() {
+                    let (section_name, entry_count) = {
+                        let s = &editor.doc.sections[section_idx];
+                        (s.name.clone(), s.entries.len())
+                    };
+                    // Section filter: match section name or any key
+                    let section_matches = needle.is_empty()
+                        || section_name.to_lowercase().contains(&needle)
+                        || editor.doc.sections[section_idx]
+                            .entries
+                            .iter()
+                            .any(|e| e.key.to_lowercase().contains(&needle));
+                    if !section_matches || entry_count == 0 {
+                        continue;
+                    }
+                    egui::CollapsingHeader::new(
+                        RichText::new(format!("{section_name}  ({entry_count})")).strong(),
+                    )
+                    .id_salt(&section_name)
+                    .default_open(!needle.is_empty())
+                    .show(ui, |ui| {
+                        for entry_idx in 0..editor.doc.sections[section_idx].entries.len() {
+                            let (key, comment, kind) = {
+                                let e = &editor.doc.sections[section_idx].entries[entry_idx];
+                                (e.key.clone(), e.comment.clone(), e.kind.clone())
+                            };
+                            if !needle.is_empty()
+                                && !key.to_lowercase().contains(&needle)
+                                && !section_name.to_lowercase().contains(&needle)
+                            {
+                                continue;
+                            }
+                            let value =
+                                &mut editor.doc.sections[section_idx].entries[entry_idx].value;
+                            let changed =
+                                entry_row(ui, &section_name, &key, &comment, &kind, value);
+                            if changed {
+                                editor.dirty = true;
+                                editor.discard_armed = false;
+                            }
+                        }
+                    });
+                }
+            });
+    });
+
+    if close {
+        state.screen = Screen::Games;
+    } else {
+        state.editor = Some(editor);
+    }
+}
+
+/// One setting row. Returns true if the value changed this frame.
+fn entry_row(
+    ui: &mut egui::Ui,
+    section: &str,
+    key: &str,
+    comment: &str,
+    kind: &ValueKind,
+    value: &mut String,
+) -> bool {
+    let mut changed = false;
+    ui.horizontal(|ui| {
+        let label = ui.label(RichText::new(key).size(13.0));
+        if !comment.is_empty() {
+            label.on_hover_text(comment);
+        }
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            let widget_id = format!("{section}.{key}");
+            match kind {
+                ValueKind::BoolOptions => {
+                    egui::ComboBox::from_id_salt(&widget_id)
+                        .selected_text(value.clone())
+                        .width(110.0)
+                        .show_ui(ui, |ui| {
+                            for option in ["true", "false", "auto"] {
+                                if ui
+                                    .selectable_value(value, option.to_string(), option)
+                                    .clicked()
+                                {
+                                    changed = true;
+                                }
+                            }
+                        });
+                }
+                ValueKind::Options(options) => {
+                    let display = options
+                        .get(value.as_str())
+                        .cloned()
+                        .unwrap_or_else(|| value.clone());
+                    egui::ComboBox::from_id_salt(&widget_id)
+                        .selected_text(display)
+                        .width(180.0)
+                        .show_ui(ui, |ui| {
+                            for (raw, label) in options {
+                                if ui.selectable_value(value, raw.clone(), label).clicked() {
+                                    changed = true;
+                                }
+                            }
+                        });
+                }
+                ValueKind::Int => {
+                    let mut parsed = value.parse::<i64>().unwrap_or(0);
+                    let response = ui.add(egui::DragValue::new(&mut parsed).speed(1));
+                    if response.changed() {
+                        *value = parsed.to_string();
+                        changed = true;
+                    }
+                }
+                ValueKind::Float => {
+                    let mut parsed = value.parse::<f64>().unwrap_or(0.0);
+                    let response = ui.add(egui::DragValue::new(&mut parsed).speed(0.05));
+                    if response.changed() {
+                        *value = format!("{parsed}");
+                        changed = true;
+                    }
+                }
+                ValueKind::Text => {
+                    let response = ui.add(egui::TextEdit::singleline(value).desired_width(180.0));
+                    if response.changed() {
+                        changed = true;
+                    }
+                }
+            }
+        });
+    });
+    changed
+}

--- a/rust/crates/optiscaler-gui/src/screens/mod.rs
+++ b/rust/crates/optiscaler-gui/src/screens/mod.rs
@@ -1,4 +1,5 @@
 pub mod games_grid;
+pub mod ini_editor;
 
 use crate::state::AppState;
 use crate::theme;

--- a/rust/crates/optiscaler-gui/src/state.rs
+++ b/rust/crates/optiscaler-gui/src/state.rs
@@ -1,6 +1,7 @@
 //! GUI state: screens, game list + filters, texture cache, log ring.
 
 use eframe::egui::{self, TextureHandle};
+use opticore::ini::{GpuVendor, IniDocument};
 use opticore::model::{Game, Platform};
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
@@ -8,9 +9,22 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Screen {
     Games,
+    IniEditor,
     Settings,
     Log,
     About,
+}
+
+/// Open OptiScaler.ini editing session for one game.
+pub struct EditorState {
+    pub game_name: String,
+    pub ini_path: PathBuf,
+    pub doc: IniDocument,
+    pub dirty: bool,
+    pub status: Option<String>,
+    pub search: String,
+    /// Set when Back was clicked with unsaved changes (second click discards).
+    pub discard_armed: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,6 +65,10 @@ pub struct AppState {
     pub anticheat_confirmed: bool,
     /// Selected proxy filename in the install flow.
     pub proxy_choice: String,
+    /// Open INI editing session (Screen::IniEditor).
+    pub editor: Option<EditorState>,
+    /// GPU vendor from the wgpu adapter, for Auto Settings.
+    pub gpu_vendor: GpuVendor,
     textures: HashMap<String, TextureHandle>,
     texture_lru: VecDeque<String>,
 }
@@ -71,8 +89,32 @@ impl Default for AppState {
             op_results: HashMap::new(),
             anticheat_confirmed: false,
             proxy_choice: "dxgi.dll".to_string(),
+            editor: None,
+            gpu_vendor: GpuVendor::Unknown,
             textures: HashMap::new(),
             texture_lru: VecDeque::new(),
+        }
+    }
+}
+
+impl AppState {
+    /// Open the INI editor for a game (install dir resolved like the installer).
+    pub fn open_editor(&mut self, game: &Game) {
+        let install_dir = opticore::install::payload::determine_install_directory(&game.path);
+        let ini_path = install_dir.join("OptiScaler.ini");
+        if let Some(doc) = opticore::ini::read_file(&ini_path) {
+            self.editor = Some(EditorState {
+                game_name: game.name.clone(),
+                ini_path,
+                doc,
+                dirty: false,
+                status: None,
+                search: String::new(),
+                discard_armed: false,
+            });
+            self.screen = Screen::IniEditor;
+        } else {
+            self.push_log(format!("Could not read {}", ini_path.display()));
         }
     }
 }


### PR DESCRIPTION
Fifth milestone: the per-game settings editor.

## opticore::ini
- Parser with the Python reader''s exact semantics — comments accumulate until the next key and drive **type inference**: `true or false`/auto comments → bool options; `0 = A | 1 = B` comment runs → enum options (with `auto` injected when the default is auto); int/float probes; else free text
- Comment-preserving serializer; saving keeps the previous file as `.ini.backup`
- Vendor-based **Auto Settings** table (NVIDIA→DLSS primary, AMD→FSR, Intel→XeSS, unknown→conservative FSR performance) — values are only applied to keys that actually exist in the file, nothing is invented

## Editor screen
"Edit settings" on an installed game opens the editor: sections as collapsing headers, widget per inferred kind (ComboBox / DragValue / TextEdit), full upstream comments as hover tooltips, key search, dirty tracking with a two-click discard guard, Save with backup, and an **Auto Settings** button using the GPU vendor read from the running wgpu adapter — the Python app''s PowerShell/wmic GPU detection has no Rust counterpart at all.

## Parity verification
`examples/ini_dump.rs` parses the **real OptiScaler 0.9.3 config** and diffs against the Python reader: **287/287 section|key|type|value lines identical.** One deliberate quirk kept for parity: a value of `auto` with "auto" anywhere in the comment classifies as bool-options even when an enum run is present, exactly like Python.

57 opticore tests, clippy `-D warnings` clean.

Note for manual testing: click a game with OptiScaler installed → **⚙ Edit settings** — worth a human pass on a real install.

Next: **M5 — global settings, config import from Python, live i18n (en/da/pl), log view polish.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)