### PR TITLE
Rust rewrite M6: GPU shader background, reduced-motion, GUI self-update

### DIFF
--- a/rust/crates/opticore/src/progress.rs
+++ b/rust/crates/opticore/src/progress.rs
@@ -29,6 +29,8 @@ pub enum TaskEvent {
     },
     /// Latest OptiScaler release tag (for update badges).
     LatestRelease { version: String },
+    /// A newer GUI release exists (version, html url).
+    GuiUpdateAvailable { version: String, url: String },
     /// A log line for the log screen.
     Log(String),
 }

--- a/rust/crates/optiscaler-gui/src/app.rs
+++ b/rust/crates/optiscaler-gui/src/app.rs
@@ -29,7 +29,11 @@ impl App {
         if let Some(render_state) = cc.wgpu_render_state.as_ref() {
             let info = render_state.adapter.get_info();
             state.gpu_vendor = opticore::ini::GpuVendor::from_pci_vendor_id(info.vendor);
+            crate::fx::EffectsRenderer::register(render_state);
         }
+        // Respect the system accessibility setting: animations disabled →
+        // background effects stay off regardless of the config toggle
+        state.reduced_motion = crate::fx::reduced_motion();
         Self {
             state,
             ops: Ops::new(),
@@ -105,6 +109,11 @@ impl App {
                         .push_log(format!("Latest OptiScaler release: {version}"));
                     self.state.latest_release = Some(version);
                 }
+                TaskEvent::GuiUpdateAvailable { version, url } => {
+                    self.state
+                        .push_log(format!("GUI update available: {version}"));
+                    self.state.gui_update = Some((version, url));
+                }
                 TaskEvent::Log(line) => self.state.push_log(line),
             }
         }
@@ -161,6 +170,17 @@ impl App {
                             .small()
                             .color(pal.text_dim),
                     );
+                    if let Some((version, url)) = self.state.gui_update.clone() {
+                        ui.hyperlink_to(
+                            RichText::new(format!(
+                                "⬆ {} {version}",
+                                self.state.i18n.tr("ui.update_available")
+                            ))
+                            .small()
+                            .color(pal.accent),
+                            url,
+                        );
+                    }
                 });
             });
     }
@@ -174,10 +194,20 @@ impl eframe::App for App {
         if !self.started {
             self.started = true;
             self.ops.spawn_catalogue_load(ctx);
-            self.ops.spawn_release_check(ctx);
+            if self.state.config.check_updates {
+                self.ops.spawn_release_check(ctx);
+                self.ops.spawn_gui_update_check(ctx);
+            }
             self.state.scan_state = ScanState::Running;
             self.ops
                 .spawn_scan(ctx, self.state.config.excluded_drive_letters());
+        }
+
+        // Repaint pacing for the animated background: ~30 fps while effects
+        // are on and the window is focused; otherwise purely event-driven
+        // (zero idle GPU/CPU cost — the toggle's real value).
+        if self.state.effects_active() && ctx.input(|i| i.focused) {
+            ctx.request_repaint_after(std::time::Duration::from_millis(33));
         }
 
         self.sidebar(ctx);

--- a/rust/crates/optiscaler-gui/src/fx/background.wgsl
+++ b/rust/crates/optiscaler-gui/src/fx/background.wgsl
@@ -1,0 +1,60 @@
+// Animated background: slow-drifting radial glows in the accent hue over a
+// dark base, with subtle film grain. Cheap by design (single fullscreen
+// triangle, a handful of ALU ops — no textures, no loops).
+
+struct Uniforms {
+    time: f32,
+    aspect: f32,
+    intensity: f32,
+    dark: f32,
+};
+
+@group(0) @binding(0) var<uniform> u: Uniforms;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    // Fullscreen triangle
+    var out: VsOut;
+    let x = f32(i32(vi & 1u) * 4 - 1);
+    let y = f32(i32(vi >> 1u) * 4 - 1);
+    out.pos = vec4<f32>(x, y, 0.0, 1.0);
+    out.uv = vec2<f32>(x * 0.5 + 0.5, 0.5 - y * 0.5);
+    return out;
+}
+
+fn hash(p: vec2<f32>) -> f32 {
+    return fract(sin(dot(p, vec2<f32>(127.1, 311.7))) * 43758.5453);
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    var uv = in.uv;
+    uv.x = uv.x * u.aspect;
+    let t = u.time * 0.05;
+
+    // Base tones follow the theme
+    let base_dark = vec3<f32>(0.055, 0.066, 0.086);
+    let base_light = vec3<f32>(0.949, 0.957, 0.969);
+    let base = mix(base_light, base_dark, u.dark);
+
+    // Two slow-orbiting glow centers in accent hues
+    let c1 = vec2<f32>(0.5 * u.aspect + 0.45 * u.aspect * cos(t),        0.30 + 0.25 * sin(t * 1.3));
+    let c2 = vec2<f32>(0.5 * u.aspect + 0.40 * u.aspect * cos(t * 0.7 + 2.6), 0.75 + 0.20 * sin(t * 0.9 + 1.2));
+    let g1 = exp(-3.5 * distance(uv, c1));
+    let g2 = exp(-4.0 * distance(uv, c2));
+
+    let accent1 = vec3<f32>(0.13, 0.32, 0.55); // deep blue
+    let accent2 = vec3<f32>(0.16, 0.42, 0.62); // teal-blue
+    var color = base + (accent1 * g1 + accent2 * g2) * 0.35 * u.intensity * mix(0.35, 1.0, u.dark);
+
+    // Subtle grain so gradients don't band
+    let grain = (hash(in.uv * 1024.0 + vec2<f32>(u.time, 0.0)) - 0.5) * 0.015;
+    color += vec3<f32>(grain);
+
+    return vec4<f32>(color, 1.0);
+}

--- a/rust/crates/optiscaler-gui/src/fx/mod.rs
+++ b/rust/crates/optiscaler-gui/src/fx/mod.rs
@@ -1,0 +1,177 @@
+//! GPU background effects: a single fullscreen-triangle wgpu pass painted
+//! behind the UI. Repaint pacing lives in App::update — when effects are
+//! off, unfocused, or reduced motion is on, this module draws nothing and
+//! costs nothing.
+
+use eframe::egui_wgpu::{self, wgpu};
+
+pub struct EffectsRenderer {
+    pipeline: wgpu::RenderPipeline,
+    bind_group: wgpu::BindGroup,
+    uniform_buffer: wgpu::Buffer,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Uniforms {
+    time: f32,
+    aspect: f32,
+    intensity: f32,
+    dark: f32,
+}
+
+impl EffectsRenderer {
+    /// Create the pipeline once and stash it in egui_wgpu's callback
+    /// resources. Call from App::new.
+    pub fn register(render_state: &egui_wgpu::RenderState) {
+        let device = &render_state.device;
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("fx_background"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("background.wgsl").into()),
+        });
+        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("fx_uniforms"),
+            size: std::mem::size_of::<Uniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("fx_bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("fx_bg"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("fx_pl"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("fx_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(render_state.target_format.into())],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        render_state
+            .renderer
+            .write()
+            .callback_resources
+            .insert(Self {
+                pipeline,
+                bind_group,
+                uniform_buffer,
+            });
+    }
+}
+
+/// Per-frame paint callback carrying the uniform values.
+pub struct EffectsCallback {
+    pub time: f32,
+    pub aspect: f32,
+    pub intensity: f32,
+    pub dark: f32,
+}
+
+impl egui_wgpu::CallbackTrait for EffectsCallback {
+    fn prepare(
+        &self,
+        _device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        _screen_descriptor: &egui_wgpu::ScreenDescriptor,
+        _egui_encoder: &mut wgpu::CommandEncoder,
+        callback_resources: &mut egui_wgpu::CallbackResources,
+    ) -> Vec<wgpu::CommandBuffer> {
+        if let Some(renderer) = callback_resources.get::<EffectsRenderer>() {
+            let uniforms = Uniforms {
+                time: self.time,
+                aspect: self.aspect,
+                intensity: self.intensity,
+                dark: self.dark,
+            };
+            let bytes = unsafe {
+                std::slice::from_raw_parts(
+                    (&uniforms as *const Uniforms) as *const u8,
+                    std::mem::size_of::<Uniforms>(),
+                )
+            };
+            queue.write_buffer(&renderer.uniform_buffer, 0, bytes);
+        }
+        Vec::new()
+    }
+
+    fn paint(
+        &self,
+        _info: eframe::epaint::PaintCallbackInfo,
+        render_pass: &mut wgpu::RenderPass<'static>,
+        callback_resources: &egui_wgpu::CallbackResources,
+    ) {
+        if let Some(renderer) = callback_resources.get::<EffectsRenderer>() {
+            render_pass.set_pipeline(&renderer.pipeline);
+            render_pass.set_bind_group(0, &renderer.bind_group, &[]);
+            render_pass.draw(0..3, 0..1);
+        }
+    }
+}
+
+/// Windows "client area animations" accessibility setting — when the user
+/// has disabled animations system-wide, effects default off. Declared
+/// directly against user32 to avoid pulling in the full windows crate.
+#[cfg(windows)]
+pub fn reduced_motion() -> bool {
+    const SPI_GETCLIENTAREAANIMATION: u32 = 0x1042;
+    #[link(name = "user32")]
+    unsafe extern "system" {
+        fn SystemParametersInfoW(
+            ui_action: u32,
+            ui_param: u32,
+            pv_param: *mut core::ffi::c_void,
+            f_win_ini: u32,
+        ) -> i32;
+    }
+    let mut animations_enabled: i32 = 1;
+    let ok = unsafe {
+        SystemParametersInfoW(
+            SPI_GETCLIENTAREAANIMATION,
+            0,
+            (&mut animations_enabled as *mut i32).cast(),
+            0,
+        )
+    };
+    ok != 0 && animations_enabled == 0
+}
+
+#[cfg(not(windows))]
+pub fn reduced_motion() -> bool {
+    false
+}

--- a/rust/crates/optiscaler-gui/src/main.rs
+++ b/rust/crates/optiscaler-gui/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app;
+mod fx;
 mod ops;
 mod screens;
 mod state;

--- a/rust/crates/optiscaler-gui/src/ops.rs
+++ b/rust/crates/optiscaler-gui/src/ops.rs
@@ -147,6 +147,29 @@ impl Ops {
         });
     }
 
+    /// Check for a newer GUI release (stable releases only — GitHub's
+    /// releases/latest endpoint excludes pre-releases).
+    pub fn spawn_gui_update_check(&self, ctx: &egui::Context) {
+        const GUI_RELEASES_LATEST: &str =
+            "https://api.github.com/repos/King4s/OptiScaler-GUI/releases/latest";
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        std::thread::spawn(move || {
+            if let Ok(release) = install::github::fetch_release_from(GUI_RELEASES_LATEST) {
+                let latest = release.version_label();
+                if install::is_update_available(opticore::VERSION, &latest) {
+                    let _ = tx.send(TaskEvent::GuiUpdateAvailable {
+                        version: latest,
+                        url: release.html_url.unwrap_or_else(|| {
+                            "https://github.com/King4s/OptiScaler-GUI/releases".to_string()
+                        }),
+                    });
+                    ctx.request_repaint();
+                }
+            }
+        });
+    }
+
     fn stage_label(stage: &InstallStage) -> String {
         match stage {
             InstallStage::FetchingRelease => "Fetching release…".into(),

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -43,6 +43,21 @@ pub fn show(ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
     }
 
     egui::CentralPanel::default().show(ctx, |ui| {
+        // Animated GPU background behind the grid (single fullscreen-triangle
+        // pass; skipped entirely when effects are off or reduced motion is on)
+        if state.effects_active() {
+            let rect = ui.max_rect().expand(8.0);
+            ui.painter()
+                .add(eframe::egui_wgpu::Callback::new_paint_callback(
+                    rect,
+                    crate::fx::EffectsCallback {
+                        time: ui.input(|i| i.time) as f32,
+                        aspect: rect.aspect_ratio(),
+                        intensity: 1.0,
+                        dark: if state.dark() { 1.0 } else { 0.0 },
+                    },
+                ));
+        }
         toolbar(ui, ctx, state, ops);
         ui.add_space(4.0);
 

--- a/rust/crates/optiscaler-gui/src/state.rs
+++ b/rust/crates/optiscaler-gui/src/state.rs
@@ -71,6 +71,10 @@ pub struct AppState {
     pub editor: Option<EditorState>,
     /// GPU vendor from the wgpu adapter, for Auto Settings.
     pub gpu_vendor: GpuVendor,
+    /// System accessibility: animations disabled → effects stay off.
+    pub reduced_motion: bool,
+    /// Newer GUI release available: (version, url).
+    pub gui_update: Option<(String, String)>,
     /// Persisted app configuration (cache/config.json, shared with Python).
     pub config: AppConfig,
     /// Path the config is saved to.
@@ -99,6 +103,8 @@ impl Default for AppState {
             proxy_choice: "dxgi.dll".to_string(),
             editor: None,
             gpu_vendor: GpuVendor::Unknown,
+            reduced_motion: false,
+            gui_update: None,
             config: AppConfig::default(),
             config_path: PathBuf::new(),
             i18n: Translator::default(),
@@ -111,6 +117,11 @@ impl Default for AppState {
 impl AppState {
     pub fn dark(&self) -> bool {
         self.config.theme != "light"
+    }
+
+    /// Effects render only when enabled and the system allows animations.
+    pub fn effects_active(&self) -> bool {
+        self.config.effects_enabled && !self.reduced_motion
     }
 
     /// Open the INI editor for a game (install dir resolved like the installer).


### PR DESCRIPTION
Seventh milestone: the GPU-powered visuals the rewrite was chosen for.

## Shader background
A single fullscreen-triangle wgpu pass (WGSL) painted behind the games grid: two slow-orbiting glows in accent hues over the theme base color, plus subtle film grain against banding. No textures, no loops — deliberately cheap. Theme-aware via a dark/light uniform.

## The toggle that actually matters
- Effects ON + window focused → `request_repaint_after(33ms)` (~30 fps cap)
- Effects OFF, window unfocused, or minimized → **purely event-driven repaints: zero idle GPU/CPU cost**
- The Settings toggle (from M5) disables the pass entirely
- **Reduced motion respected**: if Windows'' "animate controls" accessibility setting is off, effects stay off — implemented with a direct `user32` extern declaration, no new dependencies

## GUI self-update
Startup check against this repo''s releases/latest (stable releases only, gated by the update-check setting) — a sidebar badge links to the release page when a newer version exists, using the same CalVer-aware comparison as the OptiScaler update badge.

Verified: launch with effects active renders correctly (grid/cards on top of the pass, no wgpu validation errors). 62 tests, clippy `-D warnings` clean, release exe 6.9 MB.

Next: **M7 — parity checklist audit → first CalVer prerelease.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)