### PR TITLE
Rust rewrite M7: parity audit + CalVer release workflow

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,0 +1,50 @@
+name: Release (Rust)
+
+# CalVer tags: v2026.7.0, v2026.8.0-beta.1, ...
+on:
+  push:
+    tags:
+      - 'v20*'
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    working-directory: rust
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - run: cargo test --workspace
+
+      - run: cargo build --release --workspace
+
+      - name: Stage artifacts
+        shell: pwsh
+        run: |
+          $exe = "target/release/OptiScaler-GUI.exe"
+          $mb = [math]::Round((Get-Item $exe).Length / 1MB, 2)
+          Write-Host "OptiScaler-GUI.exe: $mb MB"
+          New-Item -ItemType Directory -Force out | Out-Null
+          Copy-Item $exe out/OptiScaler-GUI.exe
+          $hash = (Get-FileHash out/OptiScaler-GUI.exe -Algorithm SHA256).Hash.ToLower()
+          "$hash  OptiScaler-GUI.exe" | Out-File -Encoding ascii out/SHA256SUMS.txt
+          Get-Content out/SHA256SUMS.txt
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            rust/out/OptiScaler-GUI.exe
+            rust/out/SHA256SUMS.txt
+          prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The current release (v0.5.2) supports OptiScaler **v0.7.0 through v0.9.3** and a
 
 | Track | Where | Status |
 |---|---|---|
-| Python app (v0.x) | `src/` | ✅ Current release — maintenance mode |
-| Rust rewrite | `rust/` | 🚧 In development — GPU-rendered UI (egui/wgpu), single small exe, CalVer releases (`2026.x`) will replace the Python app at feature parity |
+| Python app (v0.x) | `src/` | ✅ Current stable release — maintenance mode |
+| Rust rewrite | `rust/` | 🧪 **Public prerelease available** — GPU-rendered UI (egui/wgpu), single ~7 MB exe, CalVer releases (`2026.x`). See [`rust/PARITY.md`](rust/PARITY.md) for the verified feature-parity status. Replaces the Python app at the first stable CalVer release. |
 
 ## Running from source
 

--- a/rust/PARITY.md
+++ b/rust/PARITY.md
@@ -1,0 +1,31 @@
+# Parity checklist — Rust rewrite vs Python v0.5.2
+
+Status per functional area, with the evidence behind each claim.
+Verified = automated test or measured comparison; Manual = needs a human pass.
+
+| Area | Status | Evidence |
+|---|---|---|
+| Steam scanning (ACF/VDF, multi-library, registry roots) | ✅ Verified | 28/28 games identical to Python on dev machine (`examples/scan_cli.rs` diff); unit tests both VDF formats |
+| Epic / GOG / Xbox / Heroic / manual-folder scanning | ✅ Verified | Same 28/28 diff (Epic 1, Xbox 7); Heroic all-4-backends unit tests ported from Python suite |
+| Engine / anti-cheat / OptiScaler-installed detection | ✅ Verified | Single-walk FolderFacts parity tests; badge spot-check via screenshots |
+| Install (download, SHA256 digest, extract, payload, manifest) | ✅ Verified | Real v0.9.3 install round-trip; digest tests incl. mismatch |
+| **Cross-app manifest contract (schema v1)** | ✅ Verified | Rust install → real Python app uninstalled cleanly (0 leftovers); Python-written fixture parsed in tests |
+| Update flow (target reuse, ini backup, stale cleanup) | ✅ Verified | winmm.dll reuse test; user-modified ini preserved in timestamped backup; v0.9.2→v0.9.3 |
+| Uninstall (manifest-based + legacy fallback) | ✅ Verified | Unit tests incl. Python-manifest fixture; real uninstall left game files intact |
+| Artwork pipeline (cache layout, CDN, Store API, SteamSpy) | ✅ Verified | Python-compatible `cache/game_images` + `steam_app_list.json`; screenshots show real art |
+| AppID matching ladder | ⚠️ Partial | Exact/normalized/suffix-strip/token-subset ported + tested. **Deviation: difflib fuzzy last-resort not ported** |
+| OptiScaler.ini editor (parse/types/write/backup) | ✅ Verified | 287/287 section\|key\|type\|value identical to Python reader on the real 0.9.3 ini |
+| Editor UI (widgets, search, dirty guard, Auto Settings) | 🖐 Manual | Compiles + logic tested; needs a human click-through on a real install |
+| GPU detection for Auto Settings | ⚠️ Simplified | wgpu adapter vendor id (no PowerShell/wmic). **Deviation: no GPU name/VRAM heuristics — FP16 recommendation always on** |
+| Global settings (language/theme/cache/excluded drives) | ✅ Verified | Config roundtrip test proves Python fields survive; live language switch |
+| i18n en/da/pl | ✅ Verified | Canonical JSON files embedded; no-extra-keys test; new keys added to all three |
+| OptiScaler update badge + GUI self-update check | ✅ Verified | Version-comparison tests; badge logic in detail panel/sidebar |
+| Progress reporting | ✅ Verified | Per-game stage progress (download %, payload count) via event channel |
+| Portable single exe | ✅ Verified | 6.9 MB release build, launch-verified; no bundled 7z.exe needed (BCJ2 in pure Rust, hash-identical to 7z.exe) |
+| Shader effects + toggle + reduced motion | ✅ Verified | Launch with pass active renders correctly; zero-idle repaint policy; SPI honored |
+
+## Known gaps (tracked for beta feedback)
+- No on-disk debug log file yet (in-app log ring only; Python writes `optiscaler_gui_debug.log`)
+- Heroic scanning verified against fixtures + store formats, not against a live Heroic install on the dev machine (none present)
+- Uninstaller `Remove OptiScaler.bat` content matches Python's shape but hasn't been executed as a standalone script in verification
+- GPU auto-recommendation simplifications listed above


### PR DESCRIPTION
Final milestone before the first public prerelease.

- **`rust/PARITY.md`** — the verified feature-parity checklist vs Python v0.5.2: what''s proven by tests/measurements (scanner 28/28, INI parser 287/287, cross-app manifest contract, update flow), what''s deliberately simplified (GPU vendor-only heuristics, no difflib fuzzy fallback), and the known gaps queued for beta feedback.
- **`release-rust.yml`** — CalVer tags (`v20*`) run the test suite, build the exe, and publish `OptiScaler-GUI.exe` + `SHA256SUMS.txt`; `-alpha`/`-beta` tags are marked as GitHub pre-releases automatically.
- README: Rust track flagged as public prerelease.

After merge: tag **`v2026.7.0-alpha.1`** → first downloadable Rust build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)