### PR TITLE
Alpha feedback: Xbox artwork, frameless window, Auto Settings diff, restore defaults

### DIFF
--- a/rust/crates/opticore/src/appids.rs
+++ b/rust/crates/opticore/src/appids.rs
@@ -195,6 +195,60 @@ impl AppIdResolver {
         result
     }
 
+    /// Online fallback via the Steam Store search API — used for games with
+    /// no local appid (typically Xbox/Game Pass titles) when the catalogue
+    /// lookup misses, e.g. before the SteamSpy download completes on first
+    /// run. The result is only accepted when the store item's name actually
+    /// matches the query (normalized equality or token-subset), so a wrong
+    /// game's artwork never wins. Memoized (positive and negative).
+    pub fn lookup_online(&self, game_name: &str) -> Option<u32> {
+        let memo_key = format!("storesearch:{}", game_name.to_lowercase());
+        if let Some(hit) = self.memo.lock().unwrap().get(&memo_key) {
+            return *hit;
+        }
+        let result = storesearch(game_name);
+        self.memo.lock().unwrap().insert(memo_key, result);
+        result
+    }
+}
+
+fn percent_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() * 3);
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+fn storesearch(game_name: &str) -> Option<u32> {
+    let url = format!(
+        "https://store.steampowered.com/api/storesearch/?term={}&cc=us&l=en",
+        percent_encode(game_name)
+    );
+    let mut resp = crate::images::http_agent().get(&url).call().ok()?;
+    let body = resp.body_mut().read_to_string().ok()?;
+    let data: Value = serde_json::from_str(&body).ok()?;
+    let query_norm = normalize(game_name);
+    let query_tokens: HashSet<&str> = query_norm.split_whitespace().collect();
+    for item in data.get("items").and_then(Value::as_array)? {
+        let name = item.get("name").and_then(Value::as_str).unwrap_or("");
+        let item_norm = normalize(name);
+        let item_tokens: HashSet<&str> = item_norm.split_whitespace().collect();
+        let acceptable = item_norm == query_norm
+            || (!query_tokens.is_empty() && query_tokens.is_subset(&item_tokens));
+        if acceptable {
+            return item.get("id").and_then(Value::as_u64).map(|id| id as u32);
+        }
+    }
+    None
+}
+
+impl AppIdResolver {
     /// Download the SteamSpy catalogue (skipped when the disk cache is fresh)
     /// and swap in the enlarged index. Call from a background thread; returns
     /// true if the index changed.

--- a/rust/crates/optiscaler-gui/src/app.rs
+++ b/rust/crates/optiscaler-gui/src/app.rs
@@ -210,6 +210,10 @@ impl eframe::App for App {
             ctx.request_repaint_after(std::time::Duration::from_millis(33));
         }
 
+        // Frameless-window chrome: top drag strip + border resize zones
+        crate::chrome::top_strip(ctx, theme::palette(self.state.dark()), "OPTISCALER GUI");
+        crate::chrome::handle_resize(ctx);
+
         self.sidebar(ctx);
         match self.state.screen {
             Screen::Games => screens::games_grid::show(ctx, &mut self.state, &mut self.ops),

--- a/rust/crates/optiscaler-gui/src/chrome.rs
+++ b/rust/crates/optiscaler-gui/src/chrome.rs
@@ -1,0 +1,94 @@
+//! Window chrome for the frameless window: a slim top strip with a drag
+//! area and minimize/maximize/close buttons, plus border resize zones.
+
+use crate::theme::Palette;
+use eframe::egui::{self, Align, CursorIcon, Layout, RichText, Sense, ViewportCommand};
+
+pub const TOP_STRIP_HEIGHT: f32 = 30.0;
+const RESIZE_MARGIN: f32 = 6.0;
+
+/// Slim custom title strip: drag-to-move, double-click to maximize,
+/// window buttons on the right.
+pub fn top_strip(ctx: &egui::Context, pal: Palette, title: &str) {
+    egui::TopBottomPanel::top("window_chrome")
+        .exact_height(TOP_STRIP_HEIGHT)
+        .frame(egui::Frame::new().fill(pal.bg))
+        .show(ctx, |ui| {
+            let strip_rect = ui.max_rect();
+
+            ui.horizontal_centered(|ui| {
+                ui.add_space(10.0);
+                ui.label(RichText::new(title).size(12.0).strong().color(pal.text_dim));
+
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    ui.spacing_mut().item_spacing.x = 2.0;
+                    let button = |text: &str| {
+                        egui::Button::new(RichText::new(text).size(13.0))
+                            .min_size(egui::vec2(34.0, TOP_STRIP_HEIGHT - 4.0))
+                            .frame(false)
+                    };
+                    if ui.add(button("✕")).clicked() {
+                        ctx.send_viewport_cmd(ViewportCommand::Close);
+                    }
+                    let maximized = ctx.input(|i| i.viewport().maximized.unwrap_or(false));
+                    if ui.add(button(if maximized { "🗗" } else { "🗖" })).clicked() {
+                        ctx.send_viewport_cmd(ViewportCommand::Maximized(!maximized));
+                    }
+                    if ui.add(button("🗕")).clicked() {
+                        ctx.send_viewport_cmd(ViewportCommand::Minimized(true));
+                    }
+                });
+            });
+
+            // Everything in the strip that isn't a button drags the window
+            let drag_response = ui.interact(
+                strip_rect,
+                egui::Id::new("window_drag_area"),
+                Sense::click_and_drag(),
+            );
+            if drag_response.drag_started() {
+                ctx.send_viewport_cmd(ViewportCommand::StartDrag);
+            }
+            if drag_response.double_clicked() {
+                let maximized = ctx.input(|i| i.viewport().maximized.unwrap_or(false));
+                ctx.send_viewport_cmd(ViewportCommand::Maximized(!maximized));
+            }
+        });
+}
+
+/// Border resize zones for the frameless window (E/W/S edges + corners;
+/// the top edge belongs to the drag strip).
+pub fn handle_resize(ctx: &egui::Context) {
+    use egui::viewport::ResizeDirection;
+    if ctx.input(|i| i.viewport().maximized.unwrap_or(false)) {
+        return;
+    }
+    let screen = ctx.content_rect();
+    let Some(pos) = ctx.input(|i| i.pointer.interact_pos()) else {
+        return;
+    };
+    let east = pos.x >= screen.max.x - RESIZE_MARGIN;
+    let west = pos.x <= screen.min.x + RESIZE_MARGIN;
+    let south = pos.y >= screen.max.y - RESIZE_MARGIN;
+    let direction = match (east, west, south) {
+        (true, _, true) => Some(ResizeDirection::SouthEast),
+        (_, true, true) => Some(ResizeDirection::SouthWest),
+        (true, _, false) => Some(ResizeDirection::East),
+        (_, true, false) => Some(ResizeDirection::West),
+        (false, false, true) => Some(ResizeDirection::South),
+        _ => None,
+    };
+    let Some(direction) = direction else { return };
+
+    let cursor = match direction {
+        ResizeDirection::East | ResizeDirection::West => CursorIcon::ResizeHorizontal,
+        ResizeDirection::South => CursorIcon::ResizeVertical,
+        ResizeDirection::SouthEast => CursorIcon::ResizeSouthEast,
+        ResizeDirection::SouthWest => CursorIcon::ResizeSouthWest,
+        _ => CursorIcon::Default,
+    };
+    ctx.set_cursor_icon(cursor);
+    if ctx.input(|i| i.pointer.primary_pressed()) {
+        ctx.send_viewport_cmd(ViewportCommand::BeginResize(direction));
+    }
+}

--- a/rust/crates/optiscaler-gui/src/main.rs
+++ b/rust/crates/optiscaler-gui/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app;
+mod chrome;
 mod fx;
 mod ops;
 mod screens;
@@ -14,6 +15,7 @@ fn main() -> eframe::Result {
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_title("OptiScaler GUI")
+            .with_decorations(false)
             .with_inner_size([1100.0, 720.0])
             .with_min_inner_size([800.0, 600.0]),
         ..Default::default()

--- a/rust/crates/optiscaler-gui/src/ops.rs
+++ b/rust/crates/optiscaler-gui/src/ops.rs
@@ -106,7 +106,9 @@ impl Ops {
         let name = game.name.clone();
         let appid = game.steam_appid;
         std::thread::spawn(move || {
-            let appid = appid.or_else(|| resolver.lookup(&name));
+            let appid = appid
+                .or_else(|| resolver.lookup(&name))
+                .or_else(|| resolver.lookup_online(&name));
             let event = match images.fetch(&name, appid) {
                 Some(path) => TaskEvent::ImageReady {
                     path_norm: key,

--- a/rust/crates/optiscaler-gui/src/screens/ini_editor.rs
+++ b/rust/crates/optiscaler-gui/src/screens/ini_editor.rs
@@ -55,17 +55,57 @@ pub fn show(ctx: &egui::Context, state: &mut AppState) {
                 .button(format!("✨ Auto Settings ({})", gpu_vendor.label()))
                 .clicked()
             {
-                let mut applied = 0;
+                let mut changes = Vec::new();
                 for (section, key, value) in auto_settings(gpu_vendor) {
-                    if editor.doc.set_value(section, key, value) {
-                        applied += 1;
+                    let old = editor.doc.get(section, key).map(|e| e.value.clone());
+                    match old {
+                        Some(old) if old != value => {
+                            editor.doc.set_value(section, key, value);
+                            changes.push(format!("{section}.{key}: {old} → {value}"));
+                        }
+                        _ => {}
                     }
                 }
-                editor.dirty = applied > 0;
+                editor.dirty = editor.dirty || !changes.is_empty();
                 editor.status = Some(format!(
-                    "Applied {applied} recommended settings for {} — review and Save",
-                    gpu_vendor.label()
+                    "Auto Settings ({}): {} changes — review below and Save",
+                    gpu_vendor.label(),
+                    changes.len()
                 ));
+                editor.applied_changes = changes;
+            }
+
+            // Restore upstream defaults from the cached release payload
+            let restore_button = egui::Button::new("↩ Restore defaults");
+            let restore = ui.add_enabled(editor.defaults.is_some(), restore_button);
+            let restore = restore.on_disabled_hover_text(
+                "Defaults come from the downloaded OptiScaler release — install or update once to enable",
+            );
+            if restore.clicked() {
+                if let Some(defaults) = editor.defaults.clone() {
+                    let mut changes = Vec::new();
+                    for section in &defaults.sections {
+                        for entry in &section.entries {
+                            let old = editor
+                                .doc
+                                .get(&section.name, &entry.key)
+                                .map(|e| e.value.clone());
+                            if let Some(old) = old {
+                                if old != entry.value {
+                                    editor.doc.set_value(&section.name, &entry.key, &entry.value);
+                                    changes.push(format!(
+                                        "{}.{}: {old} → {}",
+                                        section.name, entry.key, entry.value
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    editor.dirty = editor.dirty || !changes.is_empty();
+                    editor.status =
+                        Some(format!("Restored defaults: {} changes — Save to keep", changes.len()));
+                    editor.applied_changes = changes;
+                }
             }
             let save = egui::Button::new(RichText::new("💾 Save").strong());
             if ui.add_enabled(editor.dirty, save).clicked() {
@@ -73,6 +113,7 @@ pub fn show(ctx: &egui::Context, state: &mut AppState) {
                     Ok(()) => {
                         editor.dirty = false;
                         editor.discard_armed = false;
+                        editor.applied_changes.clear();
                         editor.status = Some("Saved (previous file kept as .ini.backup)".into());
                     }
                     Err(e) => editor.status = Some(format!("Save failed: {e}")),
@@ -85,6 +126,21 @@ pub fn show(ctx: &egui::Context, state: &mut AppState) {
             });
         });
         ui.add_space(6.0);
+
+        // What Auto Settings / Restore defaults actually changed
+        if !editor.applied_changes.is_empty() {
+            egui::CollapsingHeader::new(
+                RichText::new(format!("Changes applied ({})", editor.applied_changes.len()))
+                    .color(pal.accent),
+            )
+            .default_open(true)
+            .show(ui, |ui| {
+                for change in &editor.applied_changes {
+                    ui.label(RichText::new(change).monospace().size(12.0));
+                }
+            });
+            ui.add_space(6.0);
+        }
 
         let needle = editor.search.to_lowercase();
         egui::ScrollArea::vertical()
@@ -122,10 +178,22 @@ pub fn show(ctx: &egui::Context, state: &mut AppState) {
                             {
                                 continue;
                             }
+                            let default_value = editor
+                                .defaults
+                                .as_ref()
+                                .and_then(|d| d.get(&section_name, &key))
+                                .map(|e| e.value.clone());
                             let value =
                                 &mut editor.doc.sections[section_idx].entries[entry_idx].value;
-                            let changed =
-                                entry_row(ui, &section_name, &key, &comment, &kind, value);
+                            let changed = entry_row(
+                                ui,
+                                &section_name,
+                                &key,
+                                &comment,
+                                &kind,
+                                value,
+                                default_value.as_deref(),
+                            );
                             if changed {
                                 editor.dirty = true;
                                 editor.discard_armed = false;
@@ -144,6 +212,7 @@ pub fn show(ctx: &egui::Context, state: &mut AppState) {
 }
 
 /// One setting row. Returns true if the value changed this frame.
+#[allow(clippy::too_many_arguments)]
 fn entry_row(
     ui: &mut egui::Ui,
     section: &str,
@@ -151,6 +220,7 @@ fn entry_row(
     comment: &str,
     kind: &ValueKind,
     value: &mut String,
+    default_value: Option<&str>,
 ) -> bool {
     let mut changed = false;
     ui.horizontal(|ui| {
@@ -159,6 +229,18 @@ fn entry_row(
             label.on_hover_text(comment);
         }
         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            // Per-key reset when the value differs from the upstream default
+            if let Some(default) = default_value {
+                if default != value.as_str()
+                    && ui
+                        .small_button("↺")
+                        .on_hover_text(format!("Reset to default: {default}"))
+                        .clicked()
+                {
+                    *value = default.to_string();
+                    changed = true;
+                }
+            }
             let widget_id = format!("{section}.{key}");
             match kind {
                 ValueKind::BoolOptions => {

--- a/rust/crates/optiscaler-gui/src/state.rs
+++ b/rust/crates/optiscaler-gui/src/state.rs
@@ -22,8 +22,13 @@ pub struct EditorState {
     pub game_name: String,
     pub ini_path: PathBuf,
     pub doc: IniDocument,
+    /// Pristine upstream OptiScaler.ini from the cached release payload,
+    /// used for "Restore defaults" and per-key reset.
+    pub defaults: Option<IniDocument>,
     pub dirty: bool,
     pub status: Option<String>,
+    /// "Section.Key: old → new" lines from Auto Settings / Restore defaults.
+    pub applied_changes: Vec<String>,
     pub search: String,
     /// Set when Back was clicked with unsaved changes (second click discards).
     pub discard_armed: bool,
@@ -47,6 +52,24 @@ pub enum ArtState {
 
 const TEXTURE_CACHE_CAP: usize = 128;
 const LOG_CAP: usize = 2000;
+
+/// Pristine OptiScaler.ini from the newest cached release payload
+/// (cache/optiscaler_downloads/extracted/*/OptiScaler.ini).
+fn load_default_ini() -> Option<IniDocument> {
+    let extracted = crate::ops::base_dir()
+        .join("cache")
+        .join("optiscaler_downloads")
+        .join("extracted");
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(&extracted)
+        .ok()?
+        .flatten()
+        .map(|e| e.path().join("OptiScaler.ini"))
+        .filter(|p| p.exists())
+        .collect();
+    candidates.sort();
+    let newest = candidates.pop()?;
+    opticore::ini::read_file(&newest)
+}
 
 pub struct AppState {
     pub screen: Screen,
@@ -133,8 +156,10 @@ impl AppState {
                 game_name: game.name.clone(),
                 ini_path,
                 doc,
+                defaults: load_default_ini(),
                 dirty: false,
                 status: None,
+                applied_changes: Vec::new(),
                 search: String::new(),
                 discard_armed: false,
             });


### PR DESCRIPTION
Direct response to first alpha-testing feedback (tak!).

1. **Xbox/Game Pass artwork** — games without a Steam appid now use the Steam Store **search API fallback** with name verification (normalized equality or token-subset), so covers appear immediately instead of waiting minutes for the SteamSpy catalogue — and a wrong game''s artwork can never win. Screenshot-verified: Avowed, Balatro, Manor Lords now render; genuinely non-Steam titles (Microsoft Bubble, Minecraft for Windows) correctly keep name placeholders.
2. **Frameless window** — OS titlebar gone; slim in-app strip with drag-to-move, double-click-maximize, 🗕 🗖 ✕ buttons, and E/W/S/corner resize zones with matching cursors.
3. **Auto Settings shows its work** — a collapsible "Changes applied (N)" list with `Section.Key: old → new` lines, cleared on save.
4. **Restore defaults** (requested mid-review) — restores upstream values from the pristine `OptiScaler.ini` in the cached release payload; per-key ↺ reset buttons on any value that differs from default. Disabled with an explanatory hint until a payload has been downloaded.

62 tests, clippy clean, 6.93 MB. Tagging `v2026.7.0-alpha.2` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)