### PR TITLE
Disk logging, 100% artwork coverage, selectable background styles

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -477,6 +477,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "dataview"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daba87f72c730b508641c9fb6411fc9bba73939eed2cab611c399500511880d0"
+dependencies = [
+ "derive_pod",
+]
+
+[[package]]
 name = "der"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +500,12 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_pod"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ea6706d74fca54e15f1d40b5cf7fe7f764aaec61352a9fcec58fe27e042fc8"
 
 [[package]]
 name = "digest"
@@ -1422,6 +1437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,10 +1817,11 @@ dependencies = [
 
 [[package]]
 name = "opticore"
-version = "2026.7.0-alpha.1"
+version = "2026.7.0-alpha.3"
 dependencies = [
  "hex",
  "image",
+ "pelite",
  "serde",
  "serde_json",
  "sevenz-rust2",
@@ -1812,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "optiscaler-gui"
-version = "2026.7.0-alpha.1"
+version = "2026.7.0-alpha.3"
 dependencies = [
  "eframe",
  "image",
@@ -1871,6 +1893,25 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pelite"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88dccf4bd32294364aeb7bd55d749604450e9db54605887551f21baea7617685"
+dependencies = [
+ "dataview",
+ "libc",
+ "no-std-compat",
+ "pelite-macros",
+ "winapi",
+]
+
+[[package]]
+name = "pelite-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7cf3f8ecebb0f4895f4892a8be0a0dc81b498f9d56735cb769dc31bf00815b"
 
 [[package]]
 name = "pem-rfc7468"
@@ -3063,6 +3104,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,6 +3127,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/opticore", "crates/optiscaler-gui"]
 
 [workspace.package]
-version = "2026.7.0-alpha.1"
+version = "2026.7.0-alpha.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/King4s/OptiScaler-GUI"

--- a/rust/crates/opticore/Cargo.toml
+++ b/rust/crates/opticore/Cargo.toml
@@ -12,7 +12,8 @@ sha2 = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ureq = { version = "3", default-features = false, features = ["native-tls", "gzip"] }
-image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "ico", "bmp"] }
+pelite = "0.10"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/rust/crates/opticore/src/config.rs
+++ b/rust/crates/opticore/src/config.rs
@@ -12,6 +12,9 @@ pub struct AppConfig {
     pub theme: String,
     /// GPU background effects (M6) — on by default, off when reduced motion
     pub effects_enabled: bool,
+    /// Shader background style: "orbits" (default), "aurora", "synthwave",
+    /// or "nebula"
+    pub effects_style: String,
     /// Comma-separated uppercase drive letters, e.g. "D,E" (Python format)
     pub excluded_drives: String,
     pub check_updates: bool,
@@ -25,6 +28,7 @@ impl Default for AppConfig {
             language: "en".to_string(),
             theme: "dark".to_string(),
             effects_enabled: true,
+            effects_style: "orbits".to_string(),
             excluded_drives: String::new(),
             check_updates: true,
             passthrough: Map::new(),
@@ -69,6 +73,11 @@ impl AppConfig {
                         config.effects_enabled = b;
                     }
                 }
+                "effects_style" => {
+                    if let Some(s) = value.as_str() {
+                        config.effects_style = s.to_string();
+                    }
+                }
                 "excluded_drives" => {
                     if let Some(s) = value.as_str() {
                         config.excluded_drives = s.to_string();
@@ -96,6 +105,10 @@ impl AppConfig {
         map.insert("language".into(), Value::String(self.language.clone()));
         map.insert("theme".into(), Value::String(self.theme.clone()));
         map.insert("effects_enabled".into(), Value::Bool(self.effects_enabled));
+        map.insert(
+            "effects_style".into(),
+            Value::String(self.effects_style.clone()),
+        );
         map.insert(
             "excluded_drives".into(),
             Value::String(self.excluded_drives.clone()),

--- a/rust/crates/opticore/src/images.rs
+++ b/rust/crates/opticore/src/images.rs
@@ -55,17 +55,70 @@ impl ImageCache {
         None
     }
 
-    /// Fetch (or return cached) artwork for a game. Blocking — run on a
-    /// worker thread. Returns None when no appid or all sources fail.
-    pub fn fetch(&self, game_name: &str, appid: Option<u32>) -> Option<PathBuf> {
-        if let Some(cached) = self.cached_path(game_name, appid) {
+    /// Fetch (or return cached) artwork for a game via every source we have,
+    /// in order of quality. Blocking — run on a worker thread. The exe-icon
+    /// last resort means every game gets *something*.
+    pub fn fetch(&self, request: &ArtRequest) -> Option<PathBuf> {
+        if let Some(cached) = self.cached_path(&request.name, request.appid) {
             return Some(cached);
         }
-        let appid = appid?;
 
+        // 1. Steam CDN / Store API when we have an appid
+        if let Some(appid) = request.appid {
+            if let Some(path) = self.fetch_steam(appid) {
+                return Some(path);
+            }
+        }
+
+        // 2. Store-supplied art URL (Heroic library metadata)
+        if let Some(url) = &request.art_url {
+            if let Some(path) = self.download_and_cache(url, &self.name_stem(&request.name)) {
+                return Some(path);
+            }
+        }
+
+        // 3. GOG public search API for GOG installs
+        if request.platform_is_gog {
+            if let Some(url) = gog_search_image(&request.name) {
+                if let Some(path) = self.download_and_cache(&url, &self.name_stem(&request.name)) {
+                    return Some(path);
+                }
+            }
+        }
+
+        // 4. Xbox/Game Pass: the game ships its own store logos on disk
+        if let Some(game_path) = &request.game_path {
+            if let Some(local) = xbox_local_logo(game_path) {
+                if let Some(path) = self.cache_local_image(&local, &self.name_stem(&request.name)) {
+                    return Some(path);
+                }
+            }
+        }
+
+        // 5. Last resort: the game executable's own icon
+        if let Some(game_path) = &request.game_path {
+            if let Some(icon) = exe_icon_image(game_path) {
+                let out_path = self
+                    .cache_dir
+                    .join(format!("{}.png", self.name_stem(&request.name)));
+                if icon.save(&out_path).is_ok() {
+                    return Some(out_path);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn name_stem(&self, game_name: &str) -> String {
+        Self::safe_name(game_name)
+    }
+
+    fn fetch_steam(&self, appid: u32) -> Option<PathBuf> {
         // Primary: Steam CDN header
         let cdn_url = format!("https://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg");
-        if let Some(path) = self.download_and_cache(&cdn_url, appid) {
+        let appid_stem = format!("appid_{appid}");
+        if let Some(path) = self.download_and_cache(&cdn_url, &appid_stem) {
             return Some(path);
         }
 
@@ -84,7 +137,7 @@ impl ImageCache {
                 .and_then(|d| d.get(key))
                 .and_then(serde_json::Value::as_str)
             {
-                if let Some(path) = self.download_and_cache(url, appid) {
+                if let Some(path) = self.download_and_cache(url, &appid_stem) {
                     return Some(path);
                 }
             }
@@ -92,17 +145,189 @@ impl ImageCache {
         None
     }
 
-    fn download_and_cache(&self, url: &str, appid: u32) -> Option<PathBuf> {
-        let bytes = http_get(url)?;
-        let img = image::load_from_memory(&bytes).ok()?;
+    fn encode_to_cache(&self, img: image::DynamicImage, stem: &str) -> Option<PathBuf> {
         let img = img.thumbnail(MAX_SIZE.0, MAX_SIZE.1);
         let rgb = image::DynamicImage::ImageRgb8(img.to_rgb8());
-        let out_path = self.cache_dir.join(format!("appid_{appid}.jpg"));
+        let out_path = self.cache_dir.join(format!("{stem}.jpg"));
         let mut out = std::fs::File::create(&out_path).ok()?;
         let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, 85);
         rgb.write_with_encoder(encoder).ok()?;
         Some(out_path)
     }
+
+    fn download_and_cache(&self, url: &str, stem: &str) -> Option<PathBuf> {
+        // Heroic/GOG URLs are sometimes protocol-relative
+        let url = if url.starts_with("//") {
+            format!("https:{url}")
+        } else {
+            url.to_string()
+        };
+        let bytes = http_get(&url)?;
+        let img = image::load_from_memory(&bytes).ok()?;
+        self.encode_to_cache(img, stem)
+    }
+
+    fn cache_local_image(&self, source: &Path, stem: &str) -> Option<PathBuf> {
+        let bytes = std::fs::read(source).ok()?;
+        let img = image::load_from_memory(&bytes).ok()?;
+        self.encode_to_cache(img, stem)
+    }
+}
+
+/// Everything the artwork pipeline can use for one game.
+pub struct ArtRequest {
+    pub name: String,
+    pub appid: Option<u32>,
+    pub art_url: Option<String>,
+    pub platform_is_gog: bool,
+    pub game_path: Option<PathBuf>,
+}
+
+/// GOG's public catalogue search (no auth). Name-verified like the Steam
+/// store search so a wrong game's art can't win.
+fn gog_search_image(name: &str) -> Option<String> {
+    fn norm(s: &str) -> String {
+        s.to_lowercase()
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { ' ' })
+            .collect::<String>()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+    let encoded: String = name
+        .bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' => (b as char).to_string(),
+            b' ' => "+".to_string(),
+            _ => format!("%{b:02X}"),
+        })
+        .collect();
+    let url = format!("https://embed.gog.com/games/ajax/filtered?mediaType=game&search={encoded}");
+    let body = http_get(&url)?;
+    let data: serde_json::Value = serde_json::from_slice(&body).ok()?;
+    let query_norm = norm(name);
+    for product in data.get("products").and_then(serde_json::Value::as_array)? {
+        let title = product
+            .get("title")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        if norm(title) != query_norm {
+            continue;
+        }
+        if let Some(image) = product.get("image").and_then(serde_json::Value::as_str) {
+            return Some(format!("{image}.jpg"));
+        }
+    }
+    None
+}
+
+/// Xbox/Game Pass titles ship their store logos inside the install:
+/// MicrosoftGame.config points at Square480x480Logo/SplashScreen/StoreLogo
+/// assets. Search the config first (targeted — game content dirs are full of
+/// unrelated PNGs), preferring the larger art.
+fn xbox_local_logo(game_path: &Path) -> Option<PathBuf> {
+    let config_path = find_shallow(game_path, "MicrosoftGame.config", 2)?;
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let config_dir = config_path.parent()?;
+    for attribute in [
+        "Square480x480Logo",
+        "SplashScreenImage",
+        "StoreLogo",
+        "Square150x150Logo",
+    ] {
+        if let Some(value) = xml_attr_or_tag(&content, attribute) {
+            let candidate = config_dir.join(value.replace('\\', "/"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Pull `Name="value"` attribute or `<Name>value</Name>` element text.
+fn xml_attr_or_tag(content: &str, name: &str) -> Option<String> {
+    // attribute form
+    let attr_needle = format!("{name}=\"");
+    if let Some(pos) = content.find(&attr_needle) {
+        let rest = &content[pos + attr_needle.len()..];
+        if let Some(end) = rest.find('"') {
+            return Some(rest[..end].to_string());
+        }
+    }
+    // element form
+    let open = format!("<{name}>");
+    let close = format!("</{name}>");
+    let start = content.find(&open)? + open.len();
+    let end = content[start..].find(&close)? + start;
+    Some(content[start..end].trim().to_string())
+}
+
+/// Find a file by exact name within `max_depth` directory levels.
+fn find_shallow(root: &Path, file_name: &str, max_depth: usize) -> Option<PathBuf> {
+    let direct = root.join(file_name);
+    if direct.is_file() {
+        return Some(direct);
+    }
+    if max_depth == 0 {
+        return None;
+    }
+    for entry in std::fs::read_dir(root).ok()?.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(found) = find_shallow(&path, file_name, max_depth - 1) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// Extract the largest icon from the game's main executable (PE resources).
+/// The universal fallback: every game has an exe, every exe has an icon.
+fn exe_icon_image(game_path: &Path) -> Option<image::DynamicImage> {
+    let exe = largest_exe(game_path)?;
+    let bytes = std::fs::read(&exe).ok()?;
+    let file = pelite::PeFile::from_bytes(&bytes).ok()?;
+    let resources = file.resources().ok()?;
+    // First RT_GROUP_ICON entry, assembled into a .ico blob
+    for (_, group) in resources.icons().flatten() {
+        let mut ico = Vec::new();
+        group.write(&mut ico).ok()?;
+        if let Ok(img) = image::load_from_memory_with_format(&ico, image::ImageFormat::Ico) {
+            return Some(img);
+        }
+    }
+    None
+}
+
+/// The game's main exe: largest top-level exe, else largest within 3 levels.
+fn largest_exe(game_path: &Path) -> Option<PathBuf> {
+    fn collect(dir: &Path, depth: usize, out: &mut Vec<(u64, PathBuf)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if depth > 0 {
+                    collect(&path, depth - 1, out);
+                }
+            } else if path
+                .extension()
+                .map(|e| e.eq_ignore_ascii_case("exe"))
+                .unwrap_or(false)
+            {
+                let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+                out.push((size, path));
+            }
+        }
+    }
+    let mut exes = Vec::new();
+    collect(game_path, 3, &mut exes);
+    exes.sort();
+    exes.pop().map(|(_, path)| path)
 }
 
 /// Shared HTTP agent. ureq 3 defaults to the Rustls provider even when built

--- a/rust/crates/opticore/src/lib.rs
+++ b/rust/crates/opticore/src/lib.rs
@@ -8,6 +8,7 @@ pub mod i18n;
 pub mod images;
 pub mod ini;
 pub mod install;
+pub mod logging;
 pub mod model;
 pub mod progress;
 pub mod scan;

--- a/rust/crates/opticore/src/logging.rs
+++ b/rust/crates/opticore/src/logging.rs
@@ -1,0 +1,84 @@
+//! On-disk logging for tester bug reports: timestamped app log with simple
+//! size rotation, plus a crash-log writer for the panic hook.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const ROTATE_BYTES: u64 = 2 * 1024 * 1024;
+
+pub struct FileLog {
+    path: PathBuf,
+}
+
+impl FileLog {
+    /// Open (creating dirs) and rotate the previous log if it grew too big.
+    pub fn new(logs_dir: &Path) -> Option<Self> {
+        std::fs::create_dir_all(logs_dir).ok()?;
+        let path = logs_dir.join("optiscaler-gui.log");
+        if path
+            .metadata()
+            .map(|m| m.len() > ROTATE_BYTES)
+            .unwrap_or(false)
+        {
+            let _ = std::fs::rename(&path, logs_dir.join("optiscaler-gui.old.log"));
+        }
+        Some(Self { path })
+    }
+
+    pub fn append(&self, line: &str) {
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+        {
+            let _ = writeln!(file, "[{}] {line}", timestamp());
+        }
+    }
+
+    pub fn dir(&self) -> Option<&Path> {
+        self.path.parent()
+    }
+}
+
+fn timestamp() -> String {
+    let now = time::OffsetDateTime::now_local().unwrap_or_else(|_| time::OffsetDateTime::now_utc());
+    let format = time::macros::format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+    now.format(&format).unwrap_or_default()
+}
+
+/// Write a crash report (panic payload + location + backtrace) into the logs
+/// dir. Used by the GUI's panic hook so testers always have something to attach.
+pub fn write_crash_log(logs_dir: &Path, info: &std::panic::PanicHookInfo<'_>) {
+    let _ = std::fs::create_dir_all(logs_dir);
+    let path = logs_dir.join("crash.log");
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        let _ = writeln!(
+            file,
+            "==== crash at {} (version {}) ====\n{info}\n{backtrace}\n",
+            timestamp(),
+            crate::VERSION,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn appends_timestamped_lines_and_rotates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = FileLog::new(tmp.path()).unwrap();
+        log.append("hello");
+        log.append("world");
+        let content = std::fs::read_to_string(tmp.path().join("optiscaler-gui.log")).unwrap();
+        assert!(content.contains("] hello"));
+        assert!(content.contains("] world"));
+        assert_eq!(content.lines().count(), 2);
+    }
+}

--- a/rust/crates/opticore/src/model.rs
+++ b/rust/crates/opticore/src/model.rs
@@ -64,6 +64,9 @@ pub struct Game {
     pub anti_cheat: Vec<AntiCheat>,
     pub community_verified: bool,
     pub optiscaler_installed: bool,
+    /// Artwork URL supplied by the store's own metadata (e.g. Heroic
+    /// library art), tried before store-search fallbacks.
+    pub art_url: Option<String>,
 }
 
 impl Game {
@@ -84,6 +87,7 @@ impl Game {
             anti_cheat: Vec::new(),
             community_verified: false,
             optiscaler_installed: false,
+            art_url: None,
         }
     }
 }

--- a/rust/crates/opticore/src/scan/heroic.rs
+++ b/rust/crates/opticore/src/scan/heroic.rs
@@ -11,8 +11,14 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// (title, install_path) — title is None when only the folder name is known.
-pub type HeroicEntry = (Option<String>, PathBuf);
+/// One installed game from a Heroic store file.
+pub struct HeroicEntry {
+    /// None when only the folder name is known.
+    pub title: Option<String>,
+    pub install_path: PathBuf,
+    /// Store-supplied artwork URL when the library metadata has one.
+    pub art_url: Option<String>,
+}
 
 fn read_json(path: &Path) -> Option<Value> {
     let content = fs::read_to_string(path).ok()?;
@@ -46,16 +52,20 @@ pub fn installed_entries(root: &Path) -> Vec<HeroicEntry> {
             .join("legendary")
             .join("installed.json"),
     ) {
-        for meta in map.values() {
+        for (app_name, meta) in &map {
             if let Some(install_path) = meta.get("install_path").and_then(Value::as_str) {
                 let title = meta.get("title").and_then(Value::as_str).map(String::from);
-                entries.push((title, PathBuf::from(install_path)));
+                entries.push(HeroicEntry {
+                    title,
+                    install_path: PathBuf::from(install_path),
+                    art_url: legendary_art(root, app_name),
+                });
             }
         }
     }
 
-    // GOG titles from the library cache (newer then older location)
-    let mut gog_titles: HashMap<String, String> = HashMap::new();
+    // GOG titles + art from the library cache (newer then older location)
+    let mut gog_meta: HashMap<String, (String, Option<String>)> = HashMap::new();
     for lib_rel in [
         root.join("store_cache").join("gog_library.json"),
         root.join("gog_store").join("library.json"),
@@ -71,10 +81,15 @@ pub fn installed_entries(root: &Path) -> Vec<HeroicEntry> {
                     .or_else(|| game.get("appName"))
                     .and_then(Value::as_str);
                 let title = game.get("title").and_then(Value::as_str);
+                let art = game
+                    .get("art_cover")
+                    .or_else(|| game.get("art_square"))
+                    .and_then(Value::as_str)
+                    .map(String::from);
                 if let (Some(app), Some(title)) = (app, title) {
-                    gog_titles
+                    gog_meta
                         .entry(app.to_string())
-                        .or_insert_with(|| title.to_string());
+                        .or_insert_with(|| (title.to_string(), art));
                 }
             }
         }
@@ -91,7 +106,15 @@ pub fn installed_entries(root: &Path) -> Vec<HeroicEntry> {
                     .or_else(|| meta.get("app_name"))
                     .and_then(Value::as_str)
                     .unwrap_or("");
-                entries.push((gog_titles.get(app).cloned(), PathBuf::from(install_path)));
+                let (title, art_url) = match gog_meta.get(app) {
+                    Some((title, art)) => (Some(title.clone()), art.clone()),
+                    None => (None, None),
+                };
+                entries.push(HeroicEntry {
+                    title,
+                    install_path: PathBuf::from(install_path),
+                    art_url,
+                });
             }
         }
     }
@@ -122,7 +145,11 @@ pub fn installed_entries(root: &Path) -> Vec<HeroicEntry> {
                     .get("id")
                     .and_then(Value::as_str)
                     .and_then(|id| nile_titles.get(id).cloned());
-                entries.push((title, PathBuf::from(path)));
+                entries.push(HeroicEntry {
+                    title,
+                    install_path: PathBuf::from(path),
+                    art_url: None,
+                });
             }
         }
     }
@@ -149,12 +176,48 @@ pub fn installed_entries(root: &Path) -> Vec<HeroicEntry> {
                 });
             if let Some(folder) = folder {
                 let title = game.get("title").and_then(Value::as_str).map(String::from);
-                entries.push((title, folder));
+                let art_url = game
+                    .get("art_cover")
+                    .or_else(|| game.get("art_square"))
+                    .and_then(Value::as_str)
+                    .map(String::from);
+                entries.push(HeroicEntry {
+                    title,
+                    install_path: folder,
+                    art_url,
+                });
             }
         }
     }
 
     entries
+}
+
+/// Legendary keeps per-game metadata (incl. keyImages) in
+/// legendaryConfig/legendary/metadata/<app_name>.json.
+fn legendary_art(root: &Path, app_name: &str) -> Option<String> {
+    let meta = read_json(
+        &root
+            .join("legendaryConfig")
+            .join("legendary")
+            .join("metadata")
+            .join(format!("{app_name}.json")),
+    )?;
+    let images = meta
+        .get("metadata")
+        .and_then(|m| m.get("keyImages"))
+        .or_else(|| meta.get("keyImages"))?
+        .as_array()?;
+    for wanted in ["DieselGameBoxTall", "DieselGameBox", "OfferImageTall"] {
+        for image in images {
+            if image.get("type").and_then(Value::as_str) == Some(wanted) {
+                if let Some(url) = image.get("url").and_then(Value::as_str) {
+                    return Some(url.to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -201,7 +264,7 @@ mod tests {
 
         let mut titles: Vec<Option<String>> = installed_entries(&root)
             .into_iter()
-            .map(|(t, _)| t)
+            .map(|e| e.title)
             .collect();
         titles.sort();
         assert_eq!(titles.len(), 4);
@@ -221,7 +284,7 @@ mod tests {
         );
         let entries = installed_entries(&root);
         assert_eq!(entries.len(), 1);
-        assert!(entries[0].0.is_none());
+        assert!(entries[0].title.is_none());
     }
 
     #[test]

--- a/rust/crates/opticore/src/scan/mod.rs
+++ b/rust/crates/opticore/src/scan/mod.rs
@@ -91,6 +91,7 @@ fn build_game(
         anti_cheat: folder_facts::detect_anti_cheat(facts),
         community_verified: false, // filled by caller (needs final name)
         optiscaler_installed: folder_facts::detect_optiscaler(path, facts),
+        art_url: None,
     }
     .tap_verify(verified)
 }
@@ -244,7 +245,8 @@ fn scan_xbox_root(root: &Path, verified: &VerifiedList, games: &mut Vec<Game>) {
 fn scan_heroic(verified: &VerifiedList, games: &mut Vec<Game>) {
     let mut seen_paths = HashSet::new();
     for root in heroic::config_roots() {
-        for (title, install_path) in heroic::installed_entries(&root) {
+        for entry in heroic::installed_entries(&root) {
+            let install_path = entry.install_path;
             let norm = install_path.to_string_lossy().to_lowercase();
             if seen_paths.contains(&norm) || !install_path.is_dir() {
                 continue;
@@ -256,20 +258,22 @@ fn scan_heroic(verified: &VerifiedList, games: &mut Vec<Game>) {
                 continue;
             }
             seen_paths.insert(norm);
-            let name = title.unwrap_or_else(|| {
+            let name = entry.title.unwrap_or_else(|| {
                 install_path
                     .file_name()
                     .map(|n| n.to_string_lossy().replace(['_', '-'], " "))
                     .unwrap_or_default()
             });
-            games.push(build_game(
+            let mut game = build_game(
                 name,
                 None,
                 &install_path,
                 Platform::Heroic,
                 &facts,
                 verified,
-            ));
+            );
+            game.art_url = entry.art_url;
+            games.push(game);
         }
     }
 }

--- a/rust/crates/optiscaler-gui/src/app.rs
+++ b/rust/crates/optiscaler-gui/src/app.rs
@@ -34,6 +34,13 @@ impl App {
         // Respect the system accessibility setting: animations disabled →
         // background effects stay off regardless of the config toggle
         state.reduced_motion = crate::fx::reduced_motion();
+        // On-disk log for tester bug reports (logs/ next to the exe)
+        state.file_log = opticore::logging::FileLog::new(&crate::ops::base_dir().join("logs"));
+        state.push_log(format!(
+            "OptiScaler GUI {} started (GPU vendor: {})",
+            opticore::VERSION,
+            state.gpu_vendor.label()
+        ));
         Self {
             state,
             ops: Ops::new(),

--- a/rust/crates/optiscaler-gui/src/fx/background.wgsl
+++ b/rust/crates/optiscaler-gui/src/fx/background.wgsl
@@ -1,12 +1,20 @@
-// Animated background: slow-drifting radial glows in the accent hue over a
-// dark base, with subtle film grain. Cheap by design (single fullscreen
-// triangle, a handful of ALU ops — no textures, no loops).
+// Animated backgrounds behind the UI, selected by u.style. All styles are
+// cheap by design: single fullscreen triangle, no textures, at most three
+// noise taps.
+//   0 = Orbits    — slow-drifting radial glows (the original)
+//   1 = Aurora    — sine-wave light curtains, green/purple
+//   2 = Synthwave — perspective grid + horizon glow, magenta/cyan
+//   3 = Nebula    — layered value-noise clouds, purple/blue
 
 struct Uniforms {
     time: f32,
     aspect: f32,
     intensity: f32,
     dark: f32,
+    style: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
 };
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
@@ -31,26 +39,102 @@ fn hash(p: vec2<f32>) -> f32 {
     return fract(sin(dot(p, vec2<f32>(127.1, 311.7))) * 43758.5453);
 }
 
+fn value_noise(p: vec2<f32>) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+    let s = f * f * (3.0 - 2.0 * f);
+    let a = hash(i);
+    let b = hash(i + vec2<f32>(1.0, 0.0));
+    let c = hash(i + vec2<f32>(0.0, 1.0));
+    let d = hash(i + vec2<f32>(1.0, 1.0));
+    return mix(mix(a, b, s.x), mix(c, d, s.x), s.y);
+}
+
+// uv has x pre-scaled by aspect; raw = original 0..1 uv (for y bands).
+fn style_orbits(uv: vec2<f32>) -> vec3<f32> {
+    let t = u.time * 0.05;
+    let c1 = vec2<f32>(0.5 * u.aspect + 0.45 * u.aspect * cos(t), 0.30 + 0.25 * sin(t * 1.3));
+    let c2 = vec2<f32>(0.5 * u.aspect + 0.40 * u.aspect * cos(t * 0.7 + 2.6), 0.75 + 0.20 * sin(t * 0.9 + 1.2));
+    let g1 = exp(-3.5 * distance(uv, c1));
+    let g2 = exp(-4.0 * distance(uv, c2));
+    let accent1 = vec3<f32>(0.13, 0.32, 0.55); // deep blue
+    let accent2 = vec3<f32>(0.16, 0.42, 0.62); // teal-blue
+    return (accent1 * g1 + accent2 * g2) * 0.35;
+}
+
+fn style_aurora(raw: vec2<f32>) -> vec3<f32> {
+    let t = u.time * 0.08;
+    let x = raw.x * u.aspect;
+    let w1 = 0.12 * sin(x * 2.0 + t * 2.0) + 0.06 * sin(x * 4.3 - t * 1.4);
+    let w2 = 0.10 * sin(x * 1.6 - t * 1.7 + 2.1) + 0.05 * sin(x * 5.1 + t);
+    let band1 = exp(-14.0 * abs(raw.y - 0.32 - w1));
+    let band2 = exp(-16.0 * abs(raw.y - 0.55 - w2));
+    let green = vec3<f32>(0.08, 0.42, 0.30);
+    let purple = vec3<f32>(0.26, 0.14, 0.46);
+    // Curtains brighten toward the top of the window
+    let sky = mix(1.0, 0.4, raw.y);
+    return (green * band1 * 0.55 + purple * band2 * 0.50) * sky;
+}
+
+fn style_synthwave(raw: vec2<f32>) -> vec3<f32> {
+    let horizon = 0.60;
+    let magenta = vec3<f32>(0.48, 0.09, 0.38);
+    let cyan = vec3<f32>(0.05, 0.38, 0.46);
+    // Horizon glow on both sides
+    var color = magenta * exp(-16.0 * abs(raw.y - horizon)) * 0.6;
+    // Low sun above the horizon
+    let sun = vec2<f32>((raw.x - 0.5) * u.aspect, (raw.y - (horizon - 0.14)) * 1.4);
+    color += magenta * exp(-9.0 * length(sun)) * 0.45;
+    // Perspective grid scrolling toward the viewer below the horizon
+    let d = raw.y - horizon;
+    if d > 0.0 {
+        let pz = 1.0 / (d + 0.06);
+        let gx = abs(fract((raw.x - 0.5) * u.aspect * pz * 0.55) - 0.5);
+        let gy = abs(fract(pz * 0.45 - u.time * 0.35) - 0.5);
+        let line = max(smoothstep(0.44, 0.5, gx), smoothstep(0.42, 0.5, gy));
+        // Lines fade out right at the horizon where they'd alias
+        color += cyan * line * 0.5 * (1.0 - exp(-d * 9.0));
+    }
+    return color;
+}
+
+fn style_nebula(raw: vec2<f32>) -> vec3<f32> {
+    let t = u.time * 0.03;
+    let p = vec2<f32>(raw.x * u.aspect, raw.y) * 3.0 + vec2<f32>(t, -t * 0.7);
+    var n = value_noise(p) * 0.5;
+    n += value_noise(p * 2.1 + vec2<f32>(5.2, 1.3)) * 0.25;
+    n += value_noise(p * 4.3 + vec2<f32>(1.7, 9.2)) * 0.125;
+    n = smoothstep(0.30, 0.80, n);
+    let purple = vec3<f32>(0.33, 0.16, 0.52);
+    let blue = vec3<f32>(0.10, 0.28, 0.56);
+    let tint = mix(blue, purple, value_noise(raw * 1.5 + vec2<f32>(-t * 0.5, t * 0.3)));
+    return tint * n * 0.55;
+}
+
 @fragment
 fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     var uv = in.uv;
     uv.x = uv.x * u.aspect;
-    let t = u.time * 0.05;
 
     // Base tones follow the theme
     let base_dark = vec3<f32>(0.055, 0.066, 0.086);
     let base_light = vec3<f32>(0.949, 0.957, 0.969);
     let base = mix(base_light, base_dark, u.dark);
 
-    // Two slow-orbiting glow centers in accent hues
-    let c1 = vec2<f32>(0.5 * u.aspect + 0.45 * u.aspect * cos(t),        0.30 + 0.25 * sin(t * 1.3));
-    let c2 = vec2<f32>(0.5 * u.aspect + 0.40 * u.aspect * cos(t * 0.7 + 2.6), 0.75 + 0.20 * sin(t * 0.9 + 1.2));
-    let g1 = exp(-3.5 * distance(uv, c1));
-    let g2 = exp(-4.0 * distance(uv, c2));
+    let style = u32(u.style + 0.5);
+    var glow: vec3<f32>;
+    if style == 1u {
+        glow = style_aurora(in.uv);
+    } else if style == 2u {
+        glow = style_synthwave(in.uv);
+    } else if style == 3u {
+        glow = style_nebula(in.uv);
+    } else {
+        glow = style_orbits(uv);
+    }
 
-    let accent1 = vec3<f32>(0.13, 0.32, 0.55); // deep blue
-    let accent2 = vec3<f32>(0.16, 0.42, 0.62); // teal-blue
-    var color = base + (accent1 * g1 + accent2 * g2) * 0.35 * u.intensity * mix(0.35, 1.0, u.dark);
+    // Light theme keeps the effects subtle
+    var color = base + glow * u.intensity * mix(0.35, 1.0, u.dark);
 
     // Subtle grain so gradients don't band
     let grain = (hash(in.uv * 1024.0 + vec2<f32>(u.time, 0.0)) - 0.5) * 0.015;

--- a/rust/crates/optiscaler-gui/src/fx/mod.rs
+++ b/rust/crates/optiscaler-gui/src/fx/mod.rs
@@ -5,6 +5,25 @@
 
 use eframe::egui_wgpu::{self, wgpu};
 
+/// Selectable background styles: (config value, display label). Labels are
+/// proper names shared across languages.
+pub const STYLES: [(&str, &str); 4] = [
+    ("orbits", "Orbits"),
+    ("aurora", "Aurora"),
+    ("synthwave", "Synthwave"),
+    ("nebula", "Nebula"),
+];
+
+/// Map a config style value to the WGSL style branch index.
+pub fn style_index(name: &str) -> f32 {
+    match name {
+        "aurora" => 1.0,
+        "synthwave" => 2.0,
+        "nebula" => 3.0,
+        _ => 0.0,
+    }
+}
+
 pub struct EffectsRenderer {
     pipeline: wgpu::RenderPipeline,
     bind_group: wgpu::BindGroup,
@@ -18,6 +37,8 @@ struct Uniforms {
     aspect: f32,
     intensity: f32,
     dark: f32,
+    style: f32,
+    _pad: [f32; 3],
 }
 
 impl EffectsRenderer {
@@ -101,6 +122,8 @@ pub struct EffectsCallback {
     pub aspect: f32,
     pub intensity: f32,
     pub dark: f32,
+    /// Matches the WGSL style branch: 0 orbits, 1 aurora, 2 synthwave, 3 nebula.
+    pub style: f32,
 }
 
 impl egui_wgpu::CallbackTrait for EffectsCallback {
@@ -118,6 +141,8 @@ impl egui_wgpu::CallbackTrait for EffectsCallback {
                 aspect: self.aspect,
                 intensity: self.intensity,
                 dark: self.dark,
+                style: self.style,
+                _pad: [0.0; 3],
             };
             let bytes = unsafe {
                 std::slice::from_raw_parts(

--- a/rust/crates/optiscaler-gui/src/main.rs
+++ b/rust/crates/optiscaler-gui/src/main.rs
@@ -12,6 +12,18 @@ mod theme;
 use eframe::egui;
 
 fn main() -> eframe::Result {
+    // Crash log for tester bug reports: any panic lands in logs/crash.log
+    // next to the exe before the process dies.
+    let logs_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.join("logs")))
+        .unwrap_or_else(|| std::path::PathBuf::from("logs"));
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        opticore::logging::write_crash_log(&logs_dir, info);
+        previous_hook(info);
+    }));
+
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_title("OptiScaler GUI")

--- a/rust/crates/optiscaler-gui/src/ops.rs
+++ b/rust/crates/optiscaler-gui/src/ops.rs
@@ -3,9 +3,9 @@
 
 use eframe::egui;
 use opticore::appids::AppIdResolver;
-use opticore::images::ImageCache;
+use opticore::images::{ArtRequest, ImageCache};
 use opticore::install::{self, InstallOptions, InstallStage, Installer};
-use opticore::model::Game;
+use opticore::model::{Game, Platform};
 use opticore::progress::TaskEvent;
 use opticore::scan::{scan_all, ScanConfig};
 use std::collections::HashSet;
@@ -105,11 +105,21 @@ impl Ops {
         let images = self.images.clone();
         let name = game.name.clone();
         let appid = game.steam_appid;
+        let art_url = game.art_url.clone();
+        let platform_is_gog = game.platform == Platform::Gog;
+        let game_path = game.path.clone();
         std::thread::spawn(move || {
             let appid = appid
                 .or_else(|| resolver.lookup(&name))
                 .or_else(|| resolver.lookup_online(&name));
-            let event = match images.fetch(&name, appid) {
+            let request = ArtRequest {
+                name,
+                appid,
+                art_url,
+                platform_is_gog,
+                game_path: Some(game_path),
+            };
+            let event = match images.fetch(&request) {
                 Some(path) => TaskEvent::ImageReady {
                     path_norm: key,
                     image_path: path,

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -55,6 +55,7 @@ pub fn show(ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
                         aspect: rect.aspect_ratio(),
                         intensity: 1.0,
                         dark: if state.dark() { 1.0 } else { 0.0 },
+                        style: crate::fx::style_index(&state.config.effects_style),
                     },
                 ));
         }

--- a/rust/crates/optiscaler-gui/src/screens/mod.rs
+++ b/rust/crates/optiscaler-gui/src/screens/mod.rs
@@ -74,6 +74,32 @@ pub fn show_settings(ctx: &egui::Context, state: &mut AppState) {
             config_changed = true;
         }
 
+        // Background style picker
+        if state.config.effects_enabled {
+            ui.horizontal(|ui| {
+                ui.label(state.i18n.tr("ui.effects_style"));
+                let current_label = crate::fx::STYLES
+                    .iter()
+                    .find(|(value, _)| *value == state.config.effects_style)
+                    .map(|(_, label)| *label)
+                    .unwrap_or("Orbits");
+                egui::ComboBox::from_id_salt("effects_style")
+                    .selected_text(current_label)
+                    .show_ui(ui, |ui| {
+                        for (value, label) in crate::fx::STYLES {
+                            if ui
+                                .selectable_label(state.config.effects_style == value, label)
+                                .clicked()
+                                && state.config.effects_style != value
+                            {
+                                state.config.effects_style = value.to_string();
+                                config_changed = true;
+                            }
+                        }
+                    });
+            });
+        }
+
         // Update check opt-in
         if ui
             .checkbox(
@@ -156,6 +182,11 @@ pub fn show_log(ctx: &egui::Context, state: &mut AppState) {
             if ui.button(state.i18n.tr("ui.copy_all")).clicked() {
                 let all: String = state.log.iter().cloned().collect::<Vec<_>>().join("\n");
                 ctx.copy_text(all);
+            }
+            if let Some(dir) = state.file_log.as_ref().and_then(|l| l.dir()) {
+                if ui.button("📂 logs").clicked() {
+                    let _ = std::process::Command::new("explorer").arg(dir).spawn();
+                }
             }
         });
         ui.add_space(4.0);

--- a/rust/crates/optiscaler-gui/src/state.rs
+++ b/rust/crates/optiscaler-gui/src/state.rs
@@ -104,6 +104,8 @@ pub struct AppState {
     pub config_path: PathBuf,
     /// Active translations.
     pub i18n: Translator,
+    /// On-disk app log (logs/optiscaler-gui.log next to the exe).
+    pub file_log: Option<opticore::logging::FileLog>,
     textures: HashMap<String, TextureHandle>,
     texture_lru: VecDeque<String>,
 }
@@ -131,6 +133,7 @@ impl Default for AppState {
             config: AppConfig::default(),
             config_path: PathBuf::new(),
             i18n: Translator::default(),
+            file_log: None,
             textures: HashMap::new(),
             texture_lru: VecDeque::new(),
         }
@@ -172,6 +175,9 @@ impl AppState {
 
 impl AppState {
     pub fn push_log(&mut self, line: String) {
+        if let Some(file_log) = &self.file_log {
+            file_log.append(&line);
+        }
         if self.log.len() >= LOG_CAP {
             self.log.pop_front();
         }

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -137,7 +137,8 @@
     "effects_toggle": "GPU-baggrundseffekter",
     "excluded_drives": "Ekskluderede drev (f.eks. D,E)",
     "cache_size": "Cache-størrelse",
-    "about_tab": "Om"
+    "about_tab": "Om",
+    "effects_style": "Baggrundsstil"
   },
   "sections": {
     "OptiScaler": "OptiScaler Hoved Indstillinger",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -143,7 +143,8 @@
     "effects_toggle": "GPU background effects",
     "excluded_drives": "Excluded drives (e.g. D,E)",
     "cache_size": "Cache size",
-    "about_tab": "About"
+    "about_tab": "About",
+    "effects_style": "Background style"
   },
   "sections": {
     "OptiScaler": "OptiScaler Main Settings",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -134,7 +134,8 @@
     "excluded_drives": "Wykluczone dyski (np. D,E)",
     "cache_size": "Rozmiar cache",
     "log_tab": "Log",
-    "about_tab": "O programie"
+    "about_tab": "O programie",
+    "effects_style": "Styl tła"
   },
   "sections": {
     "OptiScaler": "OptiScaler Główne Ustawienia",


### PR DESCRIPTION
## What

Three alpha-feedback items in one PR (branch `rust/disk-logging`):

### Disk logging + crash log
- `opticore::logging::FileLog` — timestamped app log at `logs/optiscaler-gui.log` next to the exe, 2 MB rotation to `.old.log`
- Panic hook writes `logs/crash.log` with version + backtrace

### 100% artwork coverage ("Artwork in place for every gamestore")
`ImageCache::fetch(&ArtRequest)` now walks a 5-tier fallback chain so every card gets an image:
1. Steam CDN header / Store API (appid via catalogue or name-verified store search)
2. Store-supplied art URL from Heroic metadata (legendary keyImages, GOG `art_cover`, sideload)
3. GOG public catalogue search (name-verified)
4. Xbox/Game Pass: parse `MicrosoftGame.config` for the game's own store logos on disk
5. Last resort: extract the game exe's icon (pelite)

Verified on the dev machine: 28/28 games show artwork, including all Xbox titles and an exe-icon fallback case.

### Selectable background styles ("add some more backgrounds")
- Four GPU shader backgrounds: **Orbits** (default), **Aurora**, **Synthwave**, **Nebula** — one WGSL module, style branch in the fragment shader
- Picker in Settings (shown when effects are on), persisted as `effects_style` in `cache/config.json` (Python-passthrough preserved)
- New i18n key `ui.effects_style` in en/da/pl

Also bumps workspace version to `2026.7.0-alpha.3`.

## Verification
- `cargo fmt` / `clippy --all-targets` clean, 63 tests green
- App launched with each style and screenshotted; artwork grid visually confirmed full

🤖 Generated with [Claude Code](https://claude.com/claude-code)