### PR TITLE
Play button: launch with or without OptiScaler

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "opticore"
-version = "2026.7.0-alpha.4"
+version = "2026.7.0-alpha.5"
 dependencies = [
  "hex",
  "image",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "optiscaler-gui"
-version = "2026.7.0-alpha.4"
+version = "2026.7.0-alpha.5"
 dependencies = [
  "eframe",
  "image",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/opticore", "crates/optiscaler-gui"]
 
 [workspace.package]
-version = "2026.7.0-alpha.4"
+version = "2026.7.0-alpha.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/King4s/OptiScaler-GUI"

--- a/rust/crates/opticore/src/images.rs
+++ b/rust/crates/opticore/src/images.rs
@@ -303,7 +303,8 @@ fn exe_icon_image(game_path: &Path) -> Option<image::DynamicImage> {
 }
 
 /// The game's main exe: largest top-level exe, else largest within 3 levels.
-fn largest_exe(game_path: &Path) -> Option<PathBuf> {
+/// Shared with `crate::launch` as the direct-start fallback.
+pub(crate) fn largest_exe(game_path: &Path) -> Option<PathBuf> {
     fn collect(dir: &Path, depth: usize, out: &mut Vec<(u64, PathBuf)>) {
         let Ok(entries) = std::fs::read_dir(dir) else {
             return;

--- a/rust/crates/opticore/src/launch.rs
+++ b/rust/crates/opticore/src/launch.rs
@@ -1,0 +1,204 @@
+//! Launch installed games, with or without the OptiScaler proxy.
+//!
+//! "Without" renames our proxy DLL to `<name>.optiscaler-disabled` so the
+//! game boots clean; a later "with" launch renames it back. Only files named
+//! in our own install manifest are ever touched — a game's original DLLs
+//! are never renamed.
+
+use crate::install::{manifest, payload};
+use crate::model::{Game, Platform};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const DISABLED_SUFFIX: &str = ".optiscaler-disabled";
+
+/// How a game will be started.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchMethod {
+    /// Through the Steam client (overlay, cloud saves, playtime).
+    SteamUrl(String),
+    /// Direct executable start.
+    Exe(PathBuf),
+}
+
+/// Pick the best launch method for a game.
+pub fn resolve_method(game: &Game) -> Option<LaunchMethod> {
+    if game.platform == Platform::Steam {
+        if let Some(appid) = game.steam_appid {
+            return Some(LaunchMethod::SteamUrl(format!("steam://rungameid/{appid}")));
+        }
+    }
+    if game.platform == Platform::Xbox {
+        // Game Pass ships its own launcher next to the game exe; starting
+        // the exe directly is blocked by licensing/ACLs.
+        for candidate in [
+            game.path.join("Content").join("gamelaunchhelper.exe"),
+            game.path.join("gamelaunchhelper.exe"),
+        ] {
+            if candidate.exists() {
+                return Some(LaunchMethod::Exe(candidate));
+            }
+        }
+    }
+    crate::images::largest_exe(&game.path).map(LaunchMethod::Exe)
+}
+
+/// The manifest-recorded proxy target for a game, if we installed one.
+fn manifest_target(game_path: &Path) -> Option<(PathBuf, String)> {
+    let install_dir = payload::determine_install_directory(game_path);
+    let m = manifest::read(&install_dir)?;
+    if m.target_filename.is_empty() {
+        return None;
+    }
+    Some((install_dir, m.target_filename))
+}
+
+/// True when the proxy is currently renamed away ("play without" state).
+pub fn optiscaler_bypassed(game_path: &Path) -> bool {
+    match manifest_target(game_path) {
+        Some((dir, target)) => dir.join(format!("{target}{DISABLED_SUFFIX}")).exists(),
+        None => false,
+    }
+}
+
+/// Enable or bypass the installed proxy by renaming it. No-op (Ok(false))
+/// when there is no manifest or the state is already as requested.
+pub fn set_optiscaler_enabled(game_path: &Path, enabled: bool) -> std::io::Result<bool> {
+    let Some((install_dir, target)) = manifest_target(game_path) else {
+        return Ok(false);
+    };
+    let active = install_dir.join(&target);
+    let disabled = install_dir.join(format!("{target}{DISABLED_SUFFIX}"));
+    if enabled {
+        if disabled.exists() && !active.exists() {
+            std::fs::rename(&disabled, &active)?;
+            return Ok(true);
+        }
+    } else if active.exists() {
+        if disabled.exists() {
+            std::fs::remove_file(&disabled)?;
+        }
+        std::fs::rename(&active, &disabled)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+/// Toggle the proxy as requested, then start the game. Returns a log line.
+pub fn launch(game: &Game, with_optiscaler: bool) -> Result<String, String> {
+    set_optiscaler_enabled(&game.path, with_optiscaler)
+        .map_err(|e| format!("Could not toggle OptiScaler proxy: {e}"))?;
+    let method = resolve_method(game).ok_or("no executable found")?;
+    let suffix = if with_optiscaler {
+        "with OptiScaler"
+    } else {
+        "without OptiScaler"
+    };
+    match method {
+        LaunchMethod::SteamUrl(url) => {
+            // explorer hands the steam:// URL to the protocol handler
+            Command::new("explorer.exe")
+                .arg(&url)
+                .spawn()
+                .map_err(|e| e.to_string())?;
+            Ok(format!("Launching {} via Steam {suffix}", game.name))
+        }
+        LaunchMethod::Exe(exe) => {
+            let workdir = exe.parent().map(Path::to_path_buf).unwrap_or_default();
+            Command::new(&exe)
+                .current_dir(workdir)
+                .spawn()
+                .map_err(|e| e.to_string())?;
+            Ok(format!(
+                "Launching {} ({}) {suffix}",
+                game.name,
+                exe.display()
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::install::manifest::InstallManifest;
+
+    fn game_with_manifest(dir: &Path, target: &str) {
+        let m = InstallManifest::new(
+            target,
+            &[target.to_string()],
+            &[],
+            "v0.9.3",
+            None,
+            "2026-07-13T00:00:00".to_string(),
+        );
+        manifest::write(dir, &m).unwrap();
+        std::fs::write(dir.join(target), b"proxy").unwrap();
+    }
+
+    #[test]
+    fn bypass_renames_and_restore_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        game_with_manifest(tmp.path(), "dxgi.dll");
+
+        assert!(!optiscaler_bypassed(tmp.path()));
+        assert!(set_optiscaler_enabled(tmp.path(), false).unwrap());
+        assert!(optiscaler_bypassed(tmp.path()));
+        assert!(!tmp.path().join("dxgi.dll").exists());
+        assert!(tmp.path().join("dxgi.dll.optiscaler-disabled").exists());
+
+        // idempotent
+        assert!(!set_optiscaler_enabled(tmp.path(), false).unwrap());
+
+        assert!(set_optiscaler_enabled(tmp.path(), true).unwrap());
+        assert!(!optiscaler_bypassed(tmp.path()));
+        assert!(tmp.path().join("dxgi.dll").exists());
+    }
+
+    #[test]
+    fn no_manifest_means_no_touching_game_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A game that ships its OWN dxgi.dll but has no OptiScaler manifest
+        std::fs::write(tmp.path().join("dxgi.dll"), b"the game's own dll").unwrap();
+        assert!(!set_optiscaler_enabled(tmp.path(), false).unwrap());
+        assert!(tmp.path().join("dxgi.dll").exists());
+        assert!(!optiscaler_bypassed(tmp.path()));
+    }
+
+    #[test]
+    fn steam_games_resolve_to_steam_url() {
+        let mut game = Game::new("Test", std::env::temp_dir(), Platform::Steam);
+        game.steam_appid = Some(123);
+        assert_eq!(
+            resolve_method(&game),
+            Some(LaunchMethod::SteamUrl("steam://rungameid/123".into()))
+        );
+    }
+
+    #[test]
+    fn xbox_prefers_gamelaunchhelper() {
+        let tmp = tempfile::tempdir().unwrap();
+        let content = tmp.path().join("Content");
+        std::fs::create_dir_all(&content).unwrap();
+        std::fs::write(content.join("gamelaunchhelper.exe"), b"x").unwrap();
+        std::fs::write(content.join("Game.exe"), vec![0u8; 4096]).unwrap();
+
+        let game = Game::new("XG", tmp.path().to_path_buf(), Platform::Xbox);
+        assert_eq!(
+            resolve_method(&game),
+            Some(LaunchMethod::Exe(content.join("gamelaunchhelper.exe")))
+        );
+    }
+
+    #[test]
+    fn fallback_is_largest_exe() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("small.exe"), vec![0u8; 100]).unwrap();
+        std::fs::write(tmp.path().join("big.exe"), vec![0u8; 10_000]).unwrap();
+        let game = Game::new("G", tmp.path().to_path_buf(), Platform::Gog);
+        assert_eq!(
+            resolve_method(&game),
+            Some(LaunchMethod::Exe(tmp.path().join("big.exe")))
+        );
+    }
+}

--- a/rust/crates/opticore/src/lib.rs
+++ b/rust/crates/opticore/src/lib.rs
@@ -8,6 +8,7 @@ pub mod i18n;
 pub mod images;
 pub mod ini;
 pub mod install;
+pub mod launch;
 pub mod logging;
 pub mod model;
 pub mod progress;

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -830,6 +830,9 @@ fn detail_panel(
     ui.add_space(8.0);
     ui.separator();
 
+    play_section(ui, state, game, pal);
+    ui.separator();
+
     install_section(ui, ctx, state, ops, game);
 
     ui.add_space(8.0);
@@ -841,6 +844,49 @@ fn detail_panel(
             .arg(&game.path)
             .spawn();
     }
+}
+
+/// Play buttons: with OptiScaler (restores the proxy first) or without
+/// (renames our proxy away for a clean boot). Single Play when nothing is
+/// installed. Steam games start via the Steam client, Xbox via the bundled
+/// gamelaunchhelper, everything else via the game's main exe.
+fn play_section(ui: &mut egui::Ui, state: &mut AppState, game: &Game, pal: theme::Palette) {
+    ui.add_space(4.0);
+    let mut result: Option<Result<String, String>> = None;
+    if game.optiscaler_installed {
+        ui.horizontal(|ui| {
+            if ui
+                .button(RichText::new(format!("▶ {}", state.i18n.tr("ui.play_with"))).strong())
+                .clicked()
+            {
+                result = Some(opticore::launch::launch(game, true));
+            }
+            if ui
+                .button(format!("▶ {}", state.i18n.tr("ui.play_without")))
+                .clicked()
+            {
+                result = Some(opticore::launch::launch(game, false));
+            }
+        });
+        if opticore::launch::optiscaler_bypassed(&game.path) {
+            ui.label(
+                RichText::new(state.i18n.tr("ui.optiscaler_bypassed"))
+                    .small()
+                    .color(pal.badge_warn),
+            );
+        }
+    } else if ui
+        .button(RichText::new(format!("▶ {}", state.i18n.tr("ui.play"))).strong())
+        .clicked()
+    {
+        result = Some(opticore::launch::launch(game, true));
+    }
+    match result {
+        Some(Ok(message)) => state.push_log(message),
+        Some(Err(error)) => state.push_log(format!("Launch failed: {error}")),
+        None => {}
+    }
+    ui.add_space(4.0);
 }
 
 /// Install / Update / Uninstall actions with anti-cheat confirmation and

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -160,7 +160,11 @@
     "filter": "Filter",
     "all_label": "Alle",
     "ascending": "Stigende",
-    "descending": "Faldende"
+    "descending": "Faldende",
+    "play": "Spil",
+    "play_with": "Spil med OptiScaler",
+    "play_without": "Spil uden OptiScaler",
+    "optiscaler_bypassed": "OptiScaler er slået fra lige nu (proxy omdøbt). 'Spil med OptiScaler' slår den til igen."
   },
   "sections": {
     "OptiScaler": "OptiScaler Hoved Indstillinger",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -166,7 +166,11 @@
     "filter": "Filter",
     "all_label": "All",
     "ascending": "Ascending",
-    "descending": "Descending"
+    "descending": "Descending",
+    "play": "Play",
+    "play_with": "Play with OptiScaler",
+    "play_without": "Play without OptiScaler",
+    "optiscaler_bypassed": "OptiScaler is currently disabled (proxy renamed). 'Play with OptiScaler' re-enables it."
   },
   "sections": {
     "OptiScaler": "OptiScaler Main Settings",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -157,7 +157,11 @@
     "filter": "Filtr",
     "all_label": "Wszystkie",
     "ascending": "Rosnąco",
-    "descending": "Malejąco"
+    "descending": "Malejąco",
+    "play": "Graj",
+    "play_with": "Graj z OptiScaler",
+    "play_without": "Graj bez OptiScaler",
+    "optiscaler_bypassed": "OptiScaler jest obecnie wyłączony (proxy zmienione). 'Graj z OptiScaler' włączy go ponownie."
   },
   "sections": {
     "OptiScaler": "OptiScaler Główne Ustawienia",


### PR DESCRIPTION
## What

Alpha feedback: a Play button that starts the game either with or without OptiScaler.

### Launch methods (best per platform)
1. **Steam** → `steam://rungameid/<appid>` through the Steam client (overlay, cloud saves, playtime tracking)
2. **Xbox / Game Pass** → bundled `Content\gamelaunchhelper.exe` (direct exe starts are blocked by licensing; verified against the real `C:\XboxGames` layout)
3. **Everything else** → the game's main exe (largest exe heuristic shared with the icon-fallback code)

### With / without OptiScaler
- *Without*: our proxy DLL (from the install manifest's `target_filename`) is renamed to `<name>.optiscaler-disabled` before launch — the game boots clean
- *With*: the rename is reversed first, then the game starts
- Safety: only manifest-recorded files are touched — a game that ships its **own** `dxgi.dll` but has no OptiScaler install is never modified (unit-tested)
- Detail panel shows a notice while the proxy is bypassed

## Verification
- 5 new unit tests (rename round-trip, idempotency, no-manifest safety, Steam URL, Xbox helper preference, largest-exe fallback)
- fmt/clippy clean, 68 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)