### PR TITLE
fix(gui): window buttons swallowed by title-strip drag area

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "opticore"
-version = "2026.7.0-alpha.5"
+version = "2026.7.0-alpha.6"
 dependencies = [
  "hex",
  "image",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "optiscaler-gui"
-version = "2026.7.0-alpha.5"
+version = "2026.7.0-alpha.6"
 dependencies = [
  "eframe",
  "image",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/opticore", "crates/optiscaler-gui"]
 
 [workspace.package]
-version = "2026.7.0-alpha.5"
+version = "2026.7.0-alpha.6"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/King4s/OptiScaler-GUI"

--- a/rust/crates/optiscaler-gui/src/chrome.rs
+++ b/rust/crates/optiscaler-gui/src/chrome.rs
@@ -16,6 +16,21 @@ pub fn top_strip(ctx: &egui::Context, pal: Palette, title: &str) {
         .show(ctx, |ui| {
             let strip_rect = ui.max_rect();
 
+            // Register the drag area FIRST so the window buttons added after it
+            // sit on top in egui's hit test; registered last, it swallows their clicks.
+            let drag_response = ui.interact(
+                strip_rect,
+                egui::Id::new("window_drag_area"),
+                Sense::click_and_drag(),
+            );
+            if drag_response.drag_started() {
+                ctx.send_viewport_cmd(ViewportCommand::StartDrag);
+            }
+            if drag_response.double_clicked() {
+                let maximized = ctx.input(|i| i.viewport().maximized.unwrap_or(false));
+                ctx.send_viewport_cmd(ViewportCommand::Maximized(!maximized));
+            }
+
             ui.horizontal_centered(|ui| {
                 ui.add_space(10.0);
                 ui.label(RichText::new(title).size(12.0).strong().color(pal.text_dim));
@@ -39,20 +54,6 @@ pub fn top_strip(ctx: &egui::Context, pal: Palette, title: &str) {
                     }
                 });
             });
-
-            // Everything in the strip that isn't a button drags the window
-            let drag_response = ui.interact(
-                strip_rect,
-                egui::Id::new("window_drag_area"),
-                Sense::click_and_drag(),
-            );
-            if drag_response.drag_started() {
-                ctx.send_viewport_cmd(ViewportCommand::StartDrag);
-            }
-            if drag_response.double_clicked() {
-                let maximized = ctx.input(|i| i.viewport().maximized.unwrap_or(false));
-                ctx.send_viewport_cmd(ViewportCommand::Maximized(!maximized));
-            }
         });
 }
 
@@ -67,6 +68,11 @@ pub fn handle_resize(ctx: &egui::Context) {
     let Some(pos) = ctx.input(|i| i.pointer.interact_pos()) else {
         return;
     };
+    // The title strip owns the top of the window (drag + window buttons);
+    // an east-edge resize zone there would steal clicks from the ✕ button.
+    if pos.y <= screen.min.y + TOP_STRIP_HEIGHT {
+        return;
+    }
     let east = pos.x >= screen.max.x - RESIZE_MARGIN;
     let west = pos.x <= screen.min.x + RESIZE_MARGIN;
     let south = pos.y >= screen.max.y - RESIZE_MARGIN;


### PR DESCRIPTION
## Bug
The minimize/maximize/close buttons in the custom frameless chrome did nothing.

## Cause
`chrome.rs` registered the whole-strip drag interact (`Sense::click_and_drag`) **after** the window buttons. In egui's hit test the last-registered widget sits on top, so the drag area swallowed every click on the buttons. Additionally, the east-edge resize zone overlapped the outer 6 px of the close button and would start a resize on press.

## Fix
- Register the drag area first, then the buttons — same order as egui's official `custom_window_frame` example — so the buttons win the hit test.
- Exclude the title strip's height from the border resize zones (the top belongs to the drag strip anyway).

## Verification
- `cargo fmt`, `clippy -D warnings` clean, 68 tests green.
- Release build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)