### PR TITLE
feat(gui): play button on card artwork + self-healing Restore defaults

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "opticore"
-version = "2026.7.0-alpha.6"
+version = "2026.7.0-alpha.7"
 dependencies = [
  "hex",
  "image",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "optiscaler-gui"
-version = "2026.7.0-alpha.6"
+version = "2026.7.0-alpha.7"
 dependencies = [
  "eframe",
  "image",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/opticore", "crates/optiscaler-gui"]
 
 [workspace.package]
-version = "2026.7.0-alpha.6"
+version = "2026.7.0-alpha.7"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/King4s/OptiScaler-GUI"

--- a/rust/crates/opticore/src/progress.rs
+++ b/rust/crates/opticore/src/progress.rs
@@ -31,6 +31,12 @@ pub enum TaskEvent {
     LatestRelease { version: String },
     /// A newer GUI release exists (version, html url).
     GuiUpdateAvailable { version: String, url: String },
+    /// The release payload was fetched so the INI editor's "Restore defaults"
+    /// has a pristine OptiScaler.ini to compare against (None = fetch failed).
+    DefaultsFetched {
+        ini_path: Option<PathBuf>,
+        message: String,
+    },
     /// A log line for the log screen.
     Log(String),
 }

--- a/rust/crates/optiscaler-gui/src/app.rs
+++ b/rust/crates/optiscaler-gui/src/app.rs
@@ -124,6 +124,14 @@ impl App {
                         .push_log(format!("GUI update available: {version}"));
                     self.state.gui_update = Some((version, url));
                 }
+                TaskEvent::DefaultsFetched { ini_path, message } => {
+                    self.state.push_log(message.clone());
+                    if let Some(editor) = self.state.editor.as_mut() {
+                        editor.fetching_defaults = false;
+                        editor.defaults = ini_path.as_deref().and_then(opticore::ini::read_file);
+                        editor.status = Some(message);
+                    }
+                }
                 TaskEvent::Log(line) => self.state.push_log(line),
             }
         }
@@ -227,7 +235,7 @@ impl eframe::App for App {
         self.sidebar(ctx);
         match self.state.screen {
             Screen::Games => screens::games_grid::show(ctx, &mut self.state, &mut self.ops),
-            Screen::IniEditor => screens::ini_editor::show(ctx, &mut self.state),
+            Screen::IniEditor => screens::ini_editor::show(ctx, &mut self.state, &mut self.ops),
             Screen::Settings => screens::show_settings(ctx, &mut self.state),
             Screen::Log => screens::show_log(ctx, &mut self.state),
             Screen::About => screens::show_about(ctx, &mut self.state),

--- a/rust/crates/optiscaler-gui/src/ops.rs
+++ b/rust/crates/optiscaler-gui/src/ops.rs
@@ -145,6 +145,44 @@ impl Ops {
         base.join("cache").join("optiscaler_downloads")
     }
 
+    /// Download + extract the latest OptiScaler release into the cache so the
+    /// INI editor's "Restore defaults" has a pristine OptiScaler.ini. Reuses
+    /// the already-extracted payload when present (e.g. right after an
+    /// install); only needed when the download cache was cleared.
+    pub fn spawn_fetch_defaults(&self, ctx: &egui::Context) {
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        let downloads = self.downloads_dir();
+        std::thread::spawn(move || {
+            let installer = Installer::new(&downloads);
+            let event = match installer.prepare_payload(|_| {}) {
+                Ok((extracted, release)) => {
+                    let ini_path = extracted.join("OptiScaler.ini");
+                    if ini_path.exists() {
+                        TaskEvent::DefaultsFetched {
+                            ini_path: Some(ini_path),
+                            message: format!(
+                                "Defaults loaded from OptiScaler {}",
+                                release.version_label()
+                            ),
+                        }
+                    } else {
+                        TaskEvent::DefaultsFetched {
+                            ini_path: None,
+                            message: "OptiScaler.ini missing in the release payload".into(),
+                        }
+                    }
+                }
+                Err(e) => TaskEvent::DefaultsFetched {
+                    ini_path: None,
+                    message: format!("Could not fetch defaults: {e}"),
+                },
+            };
+            let _ = tx.send(event);
+            ctx.request_repaint();
+        });
+    }
+
     /// Check the latest OptiScaler release for update badges.
     pub fn spawn_release_check(&self, ctx: &egui::Context) {
         let tx = self.tx.clone();

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -447,7 +447,10 @@ fn card(
     }
 
     let selected = state.selected.as_deref() == Some(game.key.path_norm.as_str());
-    let fill = if selected || response.hovered() {
+    // Pointer-based hover: the play overlay sits on top of the card, so
+    // response.hovered() would flicker off while the pointer is on it.
+    let hovered = ui.rect_contains_pointer(rect);
+    let fill = if selected || hovered {
         pal.card_hover
     } else {
         pal.card
@@ -471,6 +474,30 @@ fn card(
         Vec2::new(dims.w - 8.0, dims.art_h),
     );
     paint_art(ui, ctx, state, ops, game, art_rect, pal);
+
+    // Play button on the artwork itself, shown on hover/selection. Registered
+    // after the card's click sense, so it wins the hit test on top of it.
+    if hovered || selected {
+        let size = Vec2::new(36.0, 28.0);
+        let btn_rect = egui::Rect::from_min_size(
+            egui::pos2(art_rect.max.x - size.x - 6.0, art_rect.max.y - size.y - 6.0),
+            size,
+        );
+        let play = ui
+            .put(
+                btn_rect,
+                egui::Button::new(RichText::new("▶").size(15.0).strong())
+                    .fill(pal.accent)
+                    .corner_radius(CornerRadius::same(14)),
+            )
+            .on_hover_text(state.i18n.tr("ui.play"));
+        if play.clicked() {
+            match opticore::launch::launch(game, true) {
+                Ok(message) => state.push_log(message),
+                Err(error) => state.push_log(format!("Launch failed: {error}")),
+            }
+        }
+    }
 
     // Name
     let name_pos = egui::pos2(rect.min.x + 8.0, art_rect.max.y + 8.0);

--- a/rust/crates/optiscaler-gui/src/screens/ini_editor.rs
+++ b/rust/crates/optiscaler-gui/src/screens/ini_editor.rs
@@ -1,12 +1,13 @@
 //! OptiScaler.ini editor: sections as collapsing headers, widgets chosen by
 //! inferred value kind, key search, dirty-state guard, GPU Auto Settings.
 
+use crate::ops::Ops;
 use crate::state::{AppState, Screen};
 use crate::theme;
 use eframe::egui::{self, Align, Layout, RichText};
 use opticore::ini::{auto_settings, ValueKind};
 
-pub fn show(ctx: &egui::Context, state: &mut AppState) {
+pub fn show(ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
     let pal = theme::palette(state.dark());
     let gpu_vendor = state.gpu_vendor;
     // Take ownership for the frame so the closure doesn't borrow `state`
@@ -75,13 +76,25 @@ pub fn show(ctx: &egui::Context, state: &mut AppState) {
                 editor.applied_changes = changes;
             }
 
-            // Restore upstream defaults from the cached release payload
-            let restore_button = egui::Button::new("↩ Restore defaults");
-            let restore = ui.add_enabled(editor.defaults.is_some(), restore_button);
-            let restore = restore.on_disabled_hover_text(
-                "Defaults come from the downloaded OptiScaler release — install or update once to enable",
-            );
-            if restore.clicked() {
+            // Restore upstream defaults from the cached release payload;
+            // when the cache is empty (fresh setup / after Clear cache) the
+            // click fetches the release in the background first.
+            if editor.fetching_defaults {
+                ui.spinner();
+                ui.label(RichText::new("Fetching defaults…").color(pal.text_dim));
+            } else if editor.defaults.is_none() {
+                if ui
+                    .button("↩ Restore defaults")
+                    .on_hover_text(
+                        "Downloads the OptiScaler release once to read its default settings",
+                    )
+                    .clicked()
+                {
+                    editor.fetching_defaults = true;
+                    editor.status = Some("Downloading OptiScaler release for defaults…".into());
+                    ops.spawn_fetch_defaults(ctx);
+                }
+            } else if ui.button("↩ Restore defaults").clicked() {
                 if let Some(defaults) = editor.defaults.clone() {
                     let mut changes = Vec::new();
                     for section in &defaults.sections {

--- a/rust/crates/optiscaler-gui/src/state.rs
+++ b/rust/crates/optiscaler-gui/src/state.rs
@@ -32,6 +32,8 @@ pub struct EditorState {
     pub search: String,
     /// Set when Back was clicked with unsaved changes (second click discards).
     pub discard_armed: bool,
+    /// A background download of the release payload (for defaults) is running.
+    pub fetching_defaults: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,6 +258,7 @@ impl AppState {
                 applied_changes: Vec::new(),
                 search: String::new(),
                 discard_armed: false,
+                fetching_defaults: false,
             });
             self.screen = Screen::IniEditor;
         } else {


### PR DESCRIPTION
Two alpha-feedback items:

## Play button on the card artwork
Hovering (or selecting) a game card now shows a ▶ overlay in the bottom-right corner of the artwork that launches the game directly (same per-platform launch logic as the detail panel: Steam client / gamelaunchhelper / game exe, with OptiScaler proxy restored first).

egui details: the overlay is registered after the card's click sense so it wins the hit test (the inverse of the chrome bug fixed in #21), and the card highlight uses `rect_contains_pointer` so it doesn't flicker while the pointer is on the button.

## "Restore defaults" was permanently disabled
The INI editor's Restore defaults compares against the pristine `OptiScaler.ini` from `cache/optiscaler_downloads/extracted/` — but that folder is deleted by Settings → Clear cache and doesn't exist on a fresh setup, leaving the button disabled with no way to fix it from the UI.

Now, when no cached payload exists, clicking the button downloads + extracts the latest release in the background (`Ops::spawn_fetch_defaults` → `TaskEvent::DefaultsFetched`) and then enables both the bulk restore and the per-key ↺ reset. The payload is the same cache the installer uses, so it's reused for the next install.

## Verification
- clippy -D warnings clean, 68 tests green, release build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)