### PR TITLE
fix(gui): move card play button below the artwork + run rustfmt

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "opticore"
-version = "2026.7.0-alpha.7"
+version = "2026.7.0-alpha.8"
 dependencies = [
  "hex",
  "image",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "optiscaler-gui"
-version = "2026.7.0-alpha.7"
+version = "2026.7.0-alpha.8"
 dependencies = [
  "eframe",
  "image",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/opticore", "crates/optiscaler-gui"]
 
 [workspace.package]
-version = "2026.7.0-alpha.7"
+version = "2026.7.0-alpha.8"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/King4s/OptiScaler-GUI"

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -475,20 +475,21 @@ fn card(
     );
     paint_art(ui, ctx, state, ops, game, art_rect, pal);
 
-    // Play button on the artwork itself, shown on hover/selection. Registered
-    // after the card's click sense, so it wins the hit test on top of it.
+    // Play button below the artwork (bottom-right of the card), shown on
+    // hover/selection. Registered after the card's click sense, so it wins
+    // the hit test on top of it.
     if hovered || selected {
-        let size = Vec2::new(36.0, 28.0);
+        let size = Vec2::new(34.0, 22.0);
         let btn_rect = egui::Rect::from_min_size(
-            egui::pos2(art_rect.max.x - size.x - 6.0, art_rect.max.y - size.y - 6.0),
+            egui::pos2(rect.max.x - size.x - 6.0, rect.max.y - size.y - 6.0),
             size,
         );
         let play = ui
             .put(
                 btn_rect,
-                egui::Button::new(RichText::new("▶").size(15.0).strong())
+                egui::Button::new(RichText::new("▶").size(13.0).strong())
                     .fill(pal.accent)
-                    .corner_radius(CornerRadius::same(14)),
+                    .corner_radius(CornerRadius::same(11)),
             )
             .on_hover_text(state.i18n.tr("ui.play"));
         if play.clicked() {

--- a/rust/crates/optiscaler-gui/src/screens/ini_editor.rs
+++ b/rust/crates/optiscaler-gui/src/screens/ini_editor.rs
@@ -105,7 +105,9 @@ pub fn show(ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
                                 .map(|e| e.value.clone());
                             if let Some(old) = old {
                                 if old != entry.value {
-                                    editor.doc.set_value(&section.name, &entry.key, &entry.value);
+                                    editor
+                                        .doc
+                                        .set_value(&section.name, &entry.key, &entry.value);
                                     changes.push(format!(
                                         "{}.{}: {old} → {}",
                                         section.name, entry.key, entry.value
@@ -115,8 +117,10 @@ pub fn show(ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
                         }
                     }
                     editor.dirty = editor.dirty || !changes.is_empty();
-                    editor.status =
-                        Some(format!("Restored defaults: {} changes — Save to keep", changes.len()));
+                    editor.status = Some(format!(
+                        "Restored defaults: {} changes — Save to keep",
+                        changes.len()
+                    ));
                     editor.applied_changes = changes;
                 }
             }
@@ -143,8 +147,11 @@ pub fn show(ctx: &egui::Context, state: &mut AppState, ops: &mut Ops) {
         // What Auto Settings / Restore defaults actually changed
         if !editor.applied_changes.is_empty() {
             egui::CollapsingHeader::new(
-                RichText::new(format!("Changes applied ({})", editor.applied_changes.len()))
-                    .color(pal.accent),
+                RichText::new(format!(
+                    "Changes applied ({})",
+                    editor.applied_changes.len()
+                ))
+                .color(pal.accent),
             )
             .default_open(true)
             .show(ui, |ui| {


### PR DESCRIPTION
- Moves the card play button from on top of the artwork to bottom-right of the card, below the art (user feedback on #22).
- Runs cargo fmt: #22 merged with a formatting diff in ini_editor.rs, which failed the lint job on main (run 29240124358). This restores a green main.

Note: the plain Python CI failure on main (run 29240124435) is unrelated — all 23 tests passed, then pytest segfaulted during interpreter teardown on the headless runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)