### PR TITLE
fix(core): retire nvngx.dll as an installable proxy, migrate on update

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "opticore"
-version = "2026.7.0-beta.1"
+version = "2026.7.0-beta.2"
 dependencies = [
  "hex",
  "image",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "optiscaler-gui"
-version = "2026.7.0-beta.1"
+version = "2026.7.0-beta.2"
 dependencies = [
  "eframe",
  "image",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/opticore", "crates/optiscaler-gui"]
 
 [workspace.package]
-version = "2026.7.0-beta.1"
+version = "2026.7.0-beta.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/King4s/OptiScaler-GUI"

--- a/rust/crates/opticore/src/install/mod.rs
+++ b/rust/crates/opticore/src/install/mod.rs
@@ -257,6 +257,7 @@ pub fn uninstall(game_path: &Path) -> Result<(Vec<String>, Vec<String>), Install
     // Legacy fallback: known file list + proxy names
     let mut legacy: Vec<&str> = payload::LEGACY_UNINSTALL_FILES.to_vec();
     legacy.extend(payload::PROXY_FILENAMES);
+    legacy.extend(payload::LEGACY_PROXY_FILENAMES);
     legacy.sort();
     legacy.dedup();
     for filename in legacy {
@@ -313,15 +314,23 @@ impl Installer {
         gpu_type: &str,
         progress: impl FnMut(InstallStage),
     ) -> Result<InstallManifest, InstallError> {
-        let target = installed_target_filename(game_path).unwrap_or_else(|| "dxgi.dll".to_string());
         let options = InstallOptions {
-            target_filename: target,
+            target_filename: update_target_filename(game_path),
             overwrite: true,
             gpu_type: gpu_type.to_string(),
             dlss_inputs: true,
         };
         self.install(game_path, &options, progress)
     }
+}
+
+/// Proxy filename an update should install with: the recorded one — except
+/// legacy names upstream no longer supports (nvngx.dll), which migrate to
+/// dxgi.dll; the stale-legacy cleanup inside install() removes the old file.
+pub fn update_target_filename(game_path: &Path) -> String {
+    installed_target_filename(game_path)
+        .filter(|t| !payload::LEGACY_PROXY_FILENAMES.contains(&t.as_str()))
+        .unwrap_or_else(|| "dxgi.dll".to_string())
 }
 
 /// Proxy filename recorded for an existing install (manifest first, then
@@ -477,6 +486,41 @@ mod tests {
             installed_target_filename(game).as_deref(),
             Some("d3d12.dll")
         );
+    }
+
+    #[test]
+    fn update_migrates_legacy_nvngx_target_to_dxgi() {
+        let tmp = tempfile::tempdir().unwrap();
+        let game = tmp.path();
+        // No install at all → default
+        assert_eq!(update_target_filename(game), "dxgi.dll");
+        // Supported recorded target is reused as-is
+        let m = InstallManifest::new(
+            "winmm.dll",
+            &["winmm.dll".into()],
+            &[],
+            "v0.9.2",
+            None,
+            "t".into(),
+        );
+        manifest::write(game, &m).unwrap();
+        assert_eq!(update_target_filename(game), "winmm.dll");
+        // nvngx.dll (unsupported upstream) migrates to the default proxy
+        let m = InstallManifest::new(
+            "nvngx.dll",
+            &["nvngx.dll".into()],
+            &[],
+            "v0.9.2",
+            None,
+            "t".into(),
+        );
+        manifest::write(game, &m).unwrap();
+        assert_eq!(update_target_filename(game), "dxgi.dll");
+        // A manifest-less nvngx.dll on disk is not treated as the target
+        std::fs::remove_file(game.join(manifest::MANIFEST_FILENAME)).unwrap();
+        File::create(game.join("nvngx.dll")).unwrap();
+        assert_eq!(installed_target_filename(game), None);
+        assert_eq!(update_target_filename(game), "dxgi.dll");
     }
 
     #[test]

--- a/rust/crates/opticore/src/install/payload.rs
+++ b/rust/crates/opticore/src/install/payload.rs
@@ -5,7 +5,8 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-/// Proxy DLL names OptiScaler can be installed as (UI order, dxgi.dll default).
+/// Proxy DLL names OptiScaler can be installed as (UI order, dxgi.dll
+/// default). Mirrors the upstream wiki's supported filename list.
 pub const PROXY_FILENAMES: &[&str] = &[
     "dxgi.dll",
     "winmm.dll",
@@ -15,8 +16,13 @@ pub const PROXY_FILENAMES: &[&str] = &[
     "wininet.dll",
     "winhttp.dll",
     "OptiScaler.asi",
-    "nvngx.dll",
 ];
+
+/// Proxy names from older OptiScaler versions that upstream no longer
+/// supports (a game only loads nvngx.dll if it calls the DLSS loader, so
+/// OptiScaler silently never starts). Not offered for new installs; kept
+/// so uninstall/cleanup still removes them and update migrates them.
+pub const LEGACY_PROXY_FILENAMES: &[&str] = &["nvngx.dll"];
 
 /// Files from older OptiScaler layouts removed before installing v0.9+ payloads.
 const STALE_LEGACY_FILES: &[&str] = &["nvapi64.dll", "nvngx.dll"];


### PR DESCRIPTION
## Why
Debugging "the Insert overlay never appears" on a real Unity game revealed it was installed with the `nvngx.dll` proxy. A game only loads `nvngx.dll` when it calls NVIDIA's DLSS loader — for everything else OptiScaler silently never starts. The upstream wiki's supported proxy list no longer includes `nvngx.dll` (dxgi, winmm, d3d12, dbghelp, version, wininet, winhttp, .asi).

The GUI has always defaulted to `dxgi.dll`, but offering `nvngx.dll` in the dropdown is a silent-failure trap, and updates reused a recorded `nvngx.dll` target forever (including installs made by older Python versions).

## Changes
- `PROXY_FILENAMES` (dropdown + target probe) no longer contains `nvngx.dll`; new `LEGACY_PROXY_FILENAMES` keeps it known for cleanup.
- New `update_target_filename()`: updates migrate legacy `nvngx.dll` targets to `dxgi.dll`; the existing stale-legacy cleanup removes the old file during install.
- Legacy manifest-less uninstall still removes `nvngx.dll`.
- New unit test covering reuse (winmm), migration (nvngx), and the manifest-less probe.

## Verification
fmt --check, clippy -D warnings, 69 tests green. Real-machine fix verified on 4 games (uninstall + reinstall as dxgi.dll via manage_cli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)