### PR TITLE
One-click GUI self-update, opt-in OptiScaler auto-update, overlay hotkey hint

### DIFF
--- a/rust/crates/opticore/src/config.rs
+++ b/rust/crates/opticore/src/config.rs
@@ -18,6 +18,8 @@ pub struct AppConfig {
     /// Comma-separated uppercase drive letters, e.g. "D,E" (Python format)
     pub excluded_drives: String,
     pub check_updates: bool,
+    /// Auto-update OptiScaler for installed games at startup (opt-in)
+    pub auto_update_optiscaler: bool,
     /// Games view: "cards_large" (default), "cards_small", "list", "details"
     pub view_mode: String,
     /// Games sort column: "name" (default), "platform", "engine", "optiscaler"
@@ -36,6 +38,7 @@ impl Default for AppConfig {
             effects_style: "orbits".to_string(),
             excluded_drives: String::new(),
             check_updates: true,
+            auto_update_optiscaler: false,
             view_mode: "cards_large".to_string(),
             sort_key: "name".to_string(),
             sort_ascending: true,
@@ -96,6 +99,11 @@ impl AppConfig {
                         config.check_updates = b;
                     }
                 }
+                "auto_update_optiscaler" => {
+                    if let Some(b) = value.as_bool() {
+                        config.auto_update_optiscaler = b;
+                    }
+                }
                 "view_mode" => {
                     if let Some(s) = value.as_str() {
                         config.view_mode = s.to_string();
@@ -137,6 +145,10 @@ impl AppConfig {
             Value::String(self.excluded_drives.clone()),
         );
         map.insert("check_updates".into(), Value::Bool(self.check_updates));
+        map.insert(
+            "auto_update_optiscaler".into(),
+            Value::Bool(self.auto_update_optiscaler),
+        );
         map.insert("view_mode".into(), Value::String(self.view_mode.clone()));
         map.insert("sort_key".into(), Value::String(self.sort_key.clone()));
         map.insert("sort_ascending".into(), Value::Bool(self.sort_ascending));

--- a/rust/crates/opticore/src/lib.rs
+++ b/rust/crates/opticore/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logging;
 pub mod model;
 pub mod progress;
 pub mod scan;
+pub mod selfupdate;
 
 /// App version (CalVer), single source of truth for the workspace.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/rust/crates/opticore/src/progress.rs
+++ b/rust/crates/opticore/src/progress.rs
@@ -31,6 +31,11 @@ pub enum TaskEvent {
     LatestRelease { version: String },
     /// A newer GUI release exists (version, html url).
     GuiUpdateAvailable { version: String, url: String },
+    /// GUI self-update download/verify progress.
+    GuiUpdateStatus {
+        phase: GuiUpdatePhase,
+        label: String,
+    },
     /// The release payload was fetched so the INI editor's "Restore defaults"
     /// has a pristine OptiScaler.ini to compare against (None = fetch failed).
     DefaultsFetched {
@@ -39,4 +44,13 @@ pub enum TaskEvent {
     },
     /// A log line for the log screen.
     Log(String),
+}
+
+/// Where a GUI self-update currently stands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuiUpdatePhase {
+    Downloading,
+    /// Verified and staged next to the exe — a restart applies it.
+    Staged,
+    Failed,
 }

--- a/rust/crates/opticore/src/selfupdate.rs
+++ b/rust/crates/opticore/src/selfupdate.rs
@@ -1,0 +1,233 @@
+//! GUI self-update: download the new exe from our releases, verify it
+//! against the published SHA256SUMS.txt, and swap it in on restart.
+//!
+//! Unlike OptiScaler archives (where a missing digest passes), the checksum
+//! is REQUIRED here — our own release pipeline always publishes sums, and a
+//! new executable must never be applied unverified.
+//!
+//! Swap dance (Windows can't overwrite a running exe, but CAN rename it):
+//! running exe → `<name>.old`, staged `<name>.update` → exe name, spawn the
+//! new exe, caller exits. `cleanup_old` removes the leftover on next start.
+
+use crate::install::github::{self, ReleaseInfo};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+pub const GUI_RELEASES_LATEST: &str =
+    "https://api.github.com/repos/King4s/OptiScaler-GUI/releases/latest";
+const EXE_ASSET: &str = "OptiScaler-GUI.exe";
+const SUMS_ASSET: &str = "SHA256SUMS.txt";
+
+#[derive(Debug)]
+pub enum SelfUpdateError {
+    Network(String),
+    MissingAsset(&'static str),
+    MissingChecksum,
+    DigestMismatch,
+    Io(String),
+}
+
+impl std::fmt::Display for SelfUpdateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SelfUpdateError::Network(e) => write!(f, "network error: {e}"),
+            SelfUpdateError::MissingAsset(name) => {
+                write!(f, "release has no {name} asset")
+            }
+            SelfUpdateError::MissingChecksum => {
+                write!(f, "release checksums do not cover the executable")
+            }
+            SelfUpdateError::DigestMismatch => {
+                write!(f, "downloaded executable failed SHA256 verification")
+            }
+            SelfUpdateError::Io(e) => write!(f, "io error: {e}"),
+        }
+    }
+}
+impl std::error::Error for SelfUpdateError {}
+
+/// The staged-download path for an exe ("<exe>.update").
+pub fn staged_path(current_exe: &Path) -> PathBuf {
+    sibling(current_exe, "update")
+}
+
+fn sibling(exe: &Path, suffix: &str) -> PathBuf {
+    let name = exe
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "OptiScaler-GUI.exe".to_string());
+    exe.with_file_name(format!("{name}.{suffix}"))
+}
+
+/// Extract the hex digest for `filename` from SHA256SUMS.txt content.
+/// Lines are "<hex>  <name>" (sha256sum format; '*' binary marker tolerated).
+pub fn checksum_for(sums: &str, filename: &str) -> Option<String> {
+    for line in sums.lines() {
+        let mut parts = line.split_whitespace();
+        let (Some(hex), Some(name)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        if name.trim_start_matches('*').eq_ignore_ascii_case(filename) && hex.len() == 64 {
+            return Some(hex.to_lowercase());
+        }
+    }
+    None
+}
+
+fn fetch_text(url: &str) -> Result<String, SelfUpdateError> {
+    let mut resp = crate::images::http_agent()
+        .get(url)
+        .header("User-Agent", "OptiScaler-GUI")
+        .call()
+        .map_err(|e| SelfUpdateError::Network(e.to_string()))?;
+    resp.body_mut()
+        .read_to_string()
+        .map_err(|e| SelfUpdateError::Network(e.to_string()))
+}
+
+/// Download the release's exe next to `current_exe` as `<name>.update` and
+/// verify it against the release's SHA256SUMS.txt. Returns the staged path.
+pub fn download_update(
+    release: &ReleaseInfo,
+    current_exe: &Path,
+    mut progress: impl FnMut(u64, u64),
+) -> Result<PathBuf, SelfUpdateError> {
+    let exe_asset = release
+        .assets
+        .iter()
+        .find(|a| a.name.eq_ignore_ascii_case(EXE_ASSET))
+        .ok_or(SelfUpdateError::MissingAsset(EXE_ASSET))?;
+    let sums_asset = release
+        .assets
+        .iter()
+        .find(|a| a.name.eq_ignore_ascii_case(SUMS_ASSET))
+        .ok_or(SelfUpdateError::MissingAsset(SUMS_ASSET))?;
+
+    let sums = fetch_text(&sums_asset.browser_download_url)?;
+    let expected = checksum_for(&sums, EXE_ASSET).ok_or(SelfUpdateError::MissingChecksum)?;
+
+    let staged = staged_path(current_exe);
+    let mut resp = crate::images::http_agent()
+        .get(&exe_asset.browser_download_url)
+        .header("User-Agent", "OptiScaler-GUI")
+        .call()
+        .map_err(|e| SelfUpdateError::Network(e.to_string()))?;
+    let total = exe_asset.size;
+    let mut out = std::fs::File::create(&staged).map_err(|e| SelfUpdateError::Io(e.to_string()))?;
+    let mut reader = resp.body_mut().as_reader();
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut downloaded: u64 = 0;
+    loop {
+        let n = reader
+            .read(&mut buf)
+            .map_err(|e| SelfUpdateError::Network(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        std::io::Write::write_all(&mut out, &buf[..n])
+            .map_err(|e| SelfUpdateError::Io(e.to_string()))?;
+        downloaded += n as u64;
+        progress(downloaded, total);
+    }
+    drop(out);
+
+    let digest = format!("sha256:{expected}");
+    if let Err(e) = github::verify_digest(&staged, Some(&digest)) {
+        let _ = std::fs::remove_file(&staged);
+        return Err(match e {
+            github::DownloadError::DigestMismatch => SelfUpdateError::DigestMismatch,
+            other => SelfUpdateError::Io(other.to_string()),
+        });
+    }
+    Ok(staged)
+}
+
+/// Rename the running exe aside and move the staged update into its place.
+/// Split from [`apply_and_restart`] so the file dance is unit-testable.
+pub fn swap_staged(current_exe: &Path) -> Result<(), SelfUpdateError> {
+    let staged = staged_path(current_exe);
+    if !staged.is_file() {
+        return Err(SelfUpdateError::Io(format!(
+            "no staged update at {}",
+            staged.display()
+        )));
+    }
+    let old = sibling(current_exe, "old");
+    if old.exists() {
+        std::fs::remove_file(&old).map_err(|e| SelfUpdateError::Io(e.to_string()))?;
+    }
+    std::fs::rename(current_exe, &old).map_err(|e| SelfUpdateError::Io(e.to_string()))?;
+    if let Err(e) = std::fs::rename(&staged, current_exe) {
+        // Restore the original so the app keeps working
+        let _ = std::fs::rename(&old, current_exe);
+        return Err(SelfUpdateError::Io(e.to_string()));
+    }
+    Ok(())
+}
+
+/// Swap the staged update in and start the new executable. On Ok the caller
+/// must exit promptly; the new instance is already running.
+pub fn apply_and_restart(current_exe: &Path) -> Result<(), SelfUpdateError> {
+    swap_staged(current_exe)?;
+    std::process::Command::new(current_exe)
+        .spawn()
+        .map_err(|e| SelfUpdateError::Io(e.to_string()))?;
+    Ok(())
+}
+
+/// Startup cleanup: remove `<exe>.old` from a completed update and any
+/// `<exe>.update` left by an interrupted download.
+pub fn cleanup_old(current_exe: &Path) {
+    let _ = std::fs::remove_file(sibling(current_exe, "old"));
+    let _ = std::fs::remove_file(sibling(current_exe, "update"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checksum_parsing() {
+        let hex = "a".repeat(64);
+        let sums = format!("{hex}  OptiScaler-GUI.exe\n{}  other.txt\n", "b".repeat(64));
+        assert_eq!(checksum_for(&sums, "OptiScaler-GUI.exe"), Some(hex.clone()));
+        // '*' binary marker and case-insensitive name
+        let starred = format!("{hex} *optiscaler-gui.exe\n");
+        assert_eq!(checksum_for(&starred, "OptiScaler-GUI.exe"), Some(hex));
+        assert_eq!(checksum_for("garbage\n", "OptiScaler-GUI.exe"), None);
+        // Truncated hash is rejected
+        assert_eq!(
+            checksum_for("abc  OptiScaler-GUI.exe\n", "OptiScaler-GUI.exe"),
+            None
+        );
+    }
+
+    #[test]
+    fn swap_dance_and_cleanup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = tmp.path().join("app.exe");
+        std::fs::write(&exe, b"old-version").unwrap();
+        std::fs::write(staged_path(&exe), b"new-version").unwrap();
+
+        swap_staged(&exe).unwrap();
+        assert_eq!(std::fs::read(&exe).unwrap(), b"new-version");
+        assert_eq!(
+            std::fs::read(tmp.path().join("app.exe.old")).unwrap(),
+            b"old-version"
+        );
+        assert!(!staged_path(&exe).exists());
+
+        cleanup_old(&exe);
+        assert!(!tmp.path().join("app.exe.old").exists());
+        assert!(exe.exists()); // the real exe is never touched by cleanup
+    }
+
+    #[test]
+    fn swap_without_staged_file_fails_cleanly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = tmp.path().join("app.exe");
+        std::fs::write(&exe, b"v1").unwrap();
+        assert!(swap_staged(&exe).is_err());
+        assert_eq!(std::fs::read(&exe).unwrap(), b"v1");
+    }
+}

--- a/rust/crates/optiscaler-gui/src/app.rs
+++ b/rust/crates/optiscaler-gui/src/app.rs
@@ -11,6 +11,8 @@ pub struct App {
     state: AppState,
     ops: Ops,
     started: bool,
+    /// Startup OptiScaler auto-update has been dispatched this session.
+    auto_update_done: bool,
 }
 
 impl App {
@@ -44,11 +46,49 @@ impl App {
             opticore::VERSION,
             state.gpu_vendor.label()
         ));
+        // Remove leftovers from a completed or interrupted self-update
+        if let Ok(exe) = std::env::current_exe() {
+            opticore::selfupdate::cleanup_old(&exe);
+        }
         Self {
             state,
             ops: Ops::new(),
             started: false,
+            auto_update_done: false,
         }
+    }
+
+    /// Opt-in startup auto-update: once the scan AND the latest-release
+    /// check have both landed, update every outdated install sequentially.
+    fn maybe_auto_update_optiscaler(&mut self, ctx: &egui::Context) {
+        if self.auto_update_done
+            || !self.state.config.auto_update_optiscaler
+            || self.state.scan_state != ScanState::Done
+        {
+            return;
+        }
+        let Some(latest) = self.state.latest_release.clone() else {
+            return;
+        };
+        self.auto_update_done = true;
+        let outdated: Vec<opticore::model::Game> = self
+            .state
+            .games
+            .iter()
+            .filter(|g| {
+                g.optiscaler_installed
+                    && opticore::install::installed_version(&g.path)
+                        .is_some_and(|v| opticore::install::is_update_available(&v, &latest))
+                    && !self.state.busy_ops.contains_key(&g.key.path_norm)
+            })
+            .cloned()
+            .collect();
+        for game in &outdated {
+            self.state
+                .busy_ops
+                .insert(game.key.path_norm.clone(), "Queued for update…".into());
+        }
+        self.ops.spawn_auto_updates(ctx, outdated);
     }
 
     fn drain_events(&mut self) {
@@ -124,6 +164,12 @@ impl App {
                         .push_log(format!("GUI update available: {version}"));
                     self.state.gui_update = Some((version, url));
                 }
+                TaskEvent::GuiUpdateStatus { phase, label } => {
+                    if phase == opticore::progress::GuiUpdatePhase::Failed {
+                        self.state.push_log(format!("GUI update failed: {label}"));
+                    }
+                    self.state.gui_update_phase = Some((phase, label));
+                }
                 TaskEvent::DefaultsFetched { ini_path, message } => {
                     self.state.push_log(message.clone());
                     if let Some(editor) = self.state.editor.as_mut() {
@@ -189,15 +235,80 @@ impl App {
                             .color(pal.text_dim),
                     );
                     if let Some((version, url)) = self.state.gui_update.clone() {
-                        ui.hyperlink_to(
-                            RichText::new(format!(
-                                "⬆ {} {version}",
-                                self.state.i18n.tr("ui.update_available")
-                            ))
-                            .small()
-                            .color(pal.accent),
-                            url,
-                        );
+                        use opticore::progress::GuiUpdatePhase;
+                        match self.state.gui_update_phase.clone() {
+                            Some((GuiUpdatePhase::Downloading, label)) => {
+                                ui.label(
+                                    RichText::new(format!(
+                                        "⬇ {} {label}",
+                                        self.state.i18n.tr("ui.update_downloading")
+                                    ))
+                                    .small()
+                                    .color(pal.accent),
+                                );
+                            }
+                            Some((GuiUpdatePhase::Staged, _)) => {
+                                if ui
+                                    .button(
+                                        RichText::new(format!(
+                                            "🔄 {}",
+                                            self.state.i18n.tr("ui.update_restart_now")
+                                        ))
+                                        .small()
+                                        .strong(),
+                                    )
+                                    .clicked()
+                                {
+                                    if let Ok(exe) = std::env::current_exe() {
+                                        match opticore::selfupdate::apply_and_restart(&exe) {
+                                            Ok(()) => {
+                                                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                                            }
+                                            Err(e) => {
+                                                self.state.gui_update_phase =
+                                                    Some((GuiUpdatePhase::Failed, e.to_string()));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            Some((GuiUpdatePhase::Failed, label)) => {
+                                ui.label(
+                                    RichText::new(format!(
+                                        "⚠ {}",
+                                        self.state.i18n.tr("ui.update_failed")
+                                    ))
+                                    .small()
+                                    .color(pal.badge_danger),
+                                )
+                                .on_hover_text(label);
+                                ui.hyperlink_to(
+                                    RichText::new(format!(
+                                        "⬆ {} {version}",
+                                        self.state.i18n.tr("ui.update_available")
+                                    ))
+                                    .small()
+                                    .color(pal.accent),
+                                    url,
+                                );
+                            }
+                            None => {
+                                if ui
+                                    .button(
+                                        RichText::new(format!(
+                                            "⬆ {} {version}",
+                                            self.state.i18n.tr("ui.update_download_restart")
+                                        ))
+                                        .small()
+                                        .strong(),
+                                    )
+                                    .on_hover_text(url)
+                                    .clicked()
+                                {
+                                    self.ops.spawn_gui_update_download(ctx);
+                                }
+                            }
+                        }
                     }
                 });
             });
@@ -207,6 +318,7 @@ impl App {
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.drain_events();
+        self.maybe_auto_update_optiscaler(ctx);
 
         // First-frame startup: catalogue load + initial scan
         if !self.started {

--- a/rust/crates/optiscaler-gui/src/main.rs
+++ b/rust/crates/optiscaler-gui/src/main.rs
@@ -8,6 +8,7 @@ mod ops;
 mod screens;
 mod state;
 mod theme;
+mod winutil;
 
 use eframe::egui;
 

--- a/rust/crates/optiscaler-gui/src/ops.rs
+++ b/rust/crates/optiscaler-gui/src/ops.rs
@@ -200,12 +200,12 @@ impl Ops {
     /// Check for a newer GUI release (stable releases only — GitHub's
     /// releases/latest endpoint excludes pre-releases).
     pub fn spawn_gui_update_check(&self, ctx: &egui::Context) {
-        const GUI_RELEASES_LATEST: &str =
-            "https://api.github.com/repos/King4s/OptiScaler-GUI/releases/latest";
         let tx = self.tx.clone();
         let ctx = ctx.clone();
         std::thread::spawn(move || {
-            if let Ok(release) = install::github::fetch_release_from(GUI_RELEASES_LATEST) {
+            if let Ok(release) =
+                install::github::fetch_release_from(opticore::selfupdate::GUI_RELEASES_LATEST)
+            {
                 let latest = release.version_label();
                 if install::is_update_available(opticore::VERSION, &latest) {
                     let _ = tx.send(TaskEvent::GuiUpdateAvailable {
@@ -216,6 +216,99 @@ impl Ops {
                     });
                     ctx.request_repaint();
                 }
+            }
+        });
+    }
+
+    /// Download + verify the new GUI exe next to the current one. The GUI
+    /// shows a "Restart now" button when the Staged phase arrives.
+    pub fn spawn_gui_update_download(&self, ctx: &egui::Context) {
+        use opticore::progress::GuiUpdatePhase;
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        std::thread::spawn(move || {
+            let send = |phase: GuiUpdatePhase, label: String| {
+                let _ = tx.send(TaskEvent::GuiUpdateStatus { phase, label });
+                ctx.request_repaint();
+            };
+            let Ok(exe) = std::env::current_exe() else {
+                send(GuiUpdatePhase::Failed, "cannot locate own exe".into());
+                return;
+            };
+            send(GuiUpdatePhase::Downloading, "0%".into());
+            let release = match install::github::fetch_release_from(
+                opticore::selfupdate::GUI_RELEASES_LATEST,
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    send(GuiUpdatePhase::Failed, e.to_string());
+                    return;
+                }
+            };
+            let progress_tx = tx.clone();
+            let progress_ctx = ctx.clone();
+            let mut last_pct = 0;
+            let result = opticore::selfupdate::download_update(&release, &exe, |done, total| {
+                if total > 0 {
+                    let pct = (done * 100 / total) as u32;
+                    if pct != last_pct {
+                        last_pct = pct;
+                        let _ = progress_tx.send(TaskEvent::GuiUpdateStatus {
+                            phase: GuiUpdatePhase::Downloading,
+                            label: format!("{pct}%"),
+                        });
+                        progress_ctx.request_repaint();
+                    }
+                }
+            });
+            match result {
+                Ok(_) => send(GuiUpdatePhase::Staged, release.version_label()),
+                Err(e) => send(GuiUpdatePhase::Failed, e.to_string()),
+            }
+        });
+    }
+
+    /// Sequentially update OptiScaler in every outdated install (opt-in
+    /// startup auto-update). One worker thread — parallel updates would race
+    /// on the shared download cache.
+    pub fn spawn_auto_updates(&self, ctx: &egui::Context, games: Vec<Game>) {
+        if games.is_empty() {
+            return;
+        }
+        let tx = self.tx.clone();
+        let ctx = ctx.clone();
+        let downloads = self.downloads_dir();
+        std::thread::spawn(move || {
+            let _ = tx.send(TaskEvent::Log(format!(
+                "Auto-updating OptiScaler in {} game(s)…",
+                games.len()
+            )));
+            for game in games {
+                let key = game.key.path_norm.clone();
+                let installer = Installer::new(&downloads);
+                let progress_tx = tx.clone();
+                let progress_ctx = ctx.clone();
+                let progress_key = key.clone();
+                let result = installer.update(&game.path, "auto", move |stage| {
+                    let _ = progress_tx.send(TaskEvent::OpProgress {
+                        path_norm: progress_key.clone(),
+                        label: Self::stage_label(&stage),
+                    });
+                    progress_ctx.request_repaint();
+                });
+                let (ok, message) = match result {
+                    Ok(m) => (
+                        true,
+                        format!("Auto-updated OptiScaler to {}", m.optiscaler_version),
+                    ),
+                    Err(e) => (false, e.to_string()),
+                };
+                let _ = tx.send(TaskEvent::OpFinished {
+                    path_norm: key,
+                    ok,
+                    message,
+                });
+                ctx.request_repaint();
             }
         });
     }

--- a/rust/crates/optiscaler-gui/src/ops.rs
+++ b/rust/crates/optiscaler-gui/src/ops.rs
@@ -249,8 +249,7 @@ impl Ops {
             let progress_ctx = ctx.clone();
             let mut last_pct = 0;
             let result = opticore::selfupdate::download_update(&release, &exe, |done, total| {
-                if total > 0 {
-                    let pct = (done * 100 / total) as u32;
+                if let Some(pct) = (done * 100).checked_div(total).map(|p| p as u32) {
                     if pct != last_pct {
                         last_pct = pct;
                         let _ = progress_tx.send(TaskEvent::GuiUpdateStatus {

--- a/rust/crates/optiscaler-gui/src/screens/games_grid.rs
+++ b/rust/crates/optiscaler-gui/src/screens/games_grid.rs
@@ -922,6 +922,14 @@ fn play_section(ui: &mut egui::Ui, state: &mut AppState, game: &Game, pal: theme
                     .color(pal.badge_warn),
             );
         }
+        // Overlay hotkey differs on non-US keyboard layouts (Alt+Insert) —
+        // the most common "overlay doesn't open" support case.
+        let overlay_hint = if crate::winutil::non_us_keyboard() {
+            state.i18n.tr("ui.overlay_hint_alt")
+        } else {
+            state.i18n.tr("ui.overlay_hint")
+        };
+        ui.label(RichText::new(overlay_hint).small().color(pal.text_dim));
     } else if ui
         .button(RichText::new(format!("▶ {}", state.i18n.tr("ui.play"))).strong())
         .clicked()

--- a/rust/crates/optiscaler-gui/src/screens/mod.rs
+++ b/rust/crates/optiscaler-gui/src/screens/mod.rs
@@ -111,6 +111,26 @@ pub fn show_settings(ctx: &egui::Context, state: &mut AppState) {
             config_changed = true;
         }
 
+        // Opt-in: auto-update OptiScaler in installed games at startup
+        if state.config.check_updates {
+            if ui
+                .checkbox(
+                    &mut state.config.auto_update_optiscaler,
+                    state.i18n.tr("ui.auto_update_optiscaler"),
+                )
+                .changed()
+            {
+                config_changed = true;
+            }
+            if state.config.auto_update_optiscaler {
+                ui.label(
+                    RichText::new(state.i18n.tr("ui.auto_update_hint"))
+                        .small()
+                        .color(pal.text_dim),
+                );
+            }
+        }
+
         // Excluded drives
         ui.horizontal(|ui| {
             ui.label(state.i18n.tr("ui.excluded_drives"));

--- a/rust/crates/optiscaler-gui/src/state.rs
+++ b/rust/crates/optiscaler-gui/src/state.rs
@@ -185,6 +185,8 @@ pub struct AppState {
     pub reduced_motion: bool,
     /// Newer GUI release available: (version, url).
     pub gui_update: Option<(String, String)>,
+    /// GUI self-update progress: current phase + label (percent/version/error).
+    pub gui_update_phase: Option<(opticore::progress::GuiUpdatePhase, String)>,
     /// Persisted app configuration (cache/config.json, shared with Python).
     pub config: AppConfig,
     /// Path the config is saved to.
@@ -223,6 +225,7 @@ impl Default for AppState {
             gpu_vendor: GpuVendor::Unknown,
             reduced_motion: false,
             gui_update: None,
+            gui_update_phase: None,
             config: AppConfig::default(),
             config_path: PathBuf::new(),
             i18n: Translator::default(),

--- a/rust/crates/optiscaler-gui/src/winutil.rs
+++ b/rust/crates/optiscaler-gui/src/winutil.rs
@@ -1,0 +1,22 @@
+//! Small OS-information helpers (direct user32 externs, no extra crates).
+
+/// True when the active keyboard layout's primary language is not US
+/// English. OptiScaler's overlay hotkey is Insert, but on alternate
+/// layouts (Danish, German, …) the overlay needs **Alt+Insert** — a
+/// frequent "overlay doesn't work" support case, so the GUI shows a hint.
+#[cfg(windows)]
+pub fn non_us_keyboard() -> bool {
+    #[link(name = "user32")]
+    unsafe extern "system" {
+        fn GetKeyboardLayout(thread_id: u32) -> isize;
+    }
+    let hkl = unsafe { GetKeyboardLayout(0) };
+    // Low word of the HKL is the language identifier; en-US is 0x0409.
+    let lang_id = (hkl as usize) & 0xFFFF;
+    lang_id != 0x0409
+}
+
+#[cfg(not(windows))]
+pub fn non_us_keyboard() -> bool {
+    false
+}

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -98,7 +98,7 @@
     "optiscaler_updated": "OptiScaler opdateret med succes",
     "update_version": "Version",
     "details": "Detaljer",
-    "update_failed": "Opdatering Mislykkedes",
+    "update_failed": "Opdatering mislykkedes",
     "failed_to_update": "Kunne ikke opdatere OptiScaler",
     "confirm_uninstall": "Bekræft Afinstallation",
     "sure_to_uninstall": "Er du sikker på, at du vil afinstallere OptiScaler fra",
@@ -164,7 +164,14 @@
     "play": "Spil",
     "play_with": "Spil med OptiScaler",
     "play_without": "Spil uden OptiScaler",
-    "optiscaler_bypassed": "OptiScaler er slået fra lige nu (proxy omdøbt). 'Spil med OptiScaler' slår den til igen."
+    "optiscaler_bypassed": "OptiScaler er slået fra lige nu (proxy omdøbt). 'Spil med OptiScaler' slår den til igen.",
+    "update_download_restart": "Opdater til",
+    "update_restart_now": "Genstart for at opdatere",
+    "update_downloading": "Henter opdatering…",
+    "auto_update_optiscaler": "Opdater OptiScaler automatisk",
+    "auto_update_hint": "Forældede installationer opdateres ved opstart. Din OptiScaler.ini sikkerhedskopieres først.",
+    "overlay_hint": "Overlay i spillet: tryk Insert",
+    "overlay_hint_alt": "Overlay i spillet: tryk Alt+Insert (dit tastaturlayout kræver Alt holdt nede)"
   },
   "sections": {
     "OptiScaler": "OptiScaler Hoved Indstillinger",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -104,7 +104,7 @@
     "optiscaler_updated": "OptiScaler updated successfully",
     "update_version": "Version",
     "details": "Details",
-    "update_failed": "Update Failed",
+    "update_failed": "Update failed",
     "failed_to_update": "Failed to update OptiScaler",
     "confirm_uninstall": "Confirm Uninstall",
     "sure_to_uninstall": "Are you sure you want to uninstall OptiScaler from",
@@ -170,7 +170,14 @@
     "play": "Play",
     "play_with": "Play with OptiScaler",
     "play_without": "Play without OptiScaler",
-    "optiscaler_bypassed": "OptiScaler is currently disabled (proxy renamed). 'Play with OptiScaler' re-enables it."
+    "optiscaler_bypassed": "OptiScaler is currently disabled (proxy renamed). 'Play with OptiScaler' re-enables it.",
+    "update_download_restart": "Update to",
+    "update_restart_now": "Restart to update",
+    "update_downloading": "Downloading update…",
+    "auto_update_optiscaler": "Update OptiScaler automatically",
+    "auto_update_hint": "Outdated installs are updated at startup. Your OptiScaler.ini is backed up first.",
+    "overlay_hint": "In-game overlay: press Insert",
+    "overlay_hint_alt": "In-game overlay: press Alt+Insert (your keyboard layout needs Alt held)"
   },
   "sections": {
     "OptiScaler": "OptiScaler Main Settings",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -94,7 +94,7 @@
     "optiscaler_updated": "OptiScaler zaktualizowany pomyślnie",
     "update_version": "Wersja",
     "details": "Szczegóły",
-    "update_failed": "Aktualizacja Nieudana",
+    "update_failed": "Aktualizacja nie powiodła się",
     "failed_to_update": "Nie udało się zaktualizować OptiScaler",
     "confirm_uninstall": "Potwierdź Odinstalowanie",
     "sure_to_uninstall": "Czy na pewno chcesz odinstalować OptiScaler z",
@@ -161,7 +161,14 @@
     "play": "Graj",
     "play_with": "Graj z OptiScaler",
     "play_without": "Graj bez OptiScaler",
-    "optiscaler_bypassed": "OptiScaler jest obecnie wyłączony (proxy zmienione). 'Graj z OptiScaler' włączy go ponownie."
+    "optiscaler_bypassed": "OptiScaler jest obecnie wyłączony (proxy zmienione). 'Graj z OptiScaler' włączy go ponownie.",
+    "update_download_restart": "Aktualizuj do",
+    "update_restart_now": "Uruchom ponownie, aby zaktualizować",
+    "update_downloading": "Pobieranie aktualizacji…",
+    "auto_update_optiscaler": "Aktualizuj OptiScaler automatycznie",
+    "auto_update_hint": "Nieaktualne instalacje są aktualizowane przy starcie. Twój OptiScaler.ini jest najpierw archiwizowany.",
+    "overlay_hint": "Nakładka w grze: naciśnij Insert",
+    "overlay_hint_alt": "Nakładka w grze: naciśnij Alt+Insert (twój układ klawiatury wymaga wciśniętego Alt)"
   },
   "sections": {
     "OptiScaler": "OptiScaler Główne Ustawienia",


### PR DESCRIPTION
Three user-facing additions (requested 2026-08-02):

## 1. GUI self-update — one click + restart
- New `opticore::selfupdate`: downloads the new `OptiScaler-GUI.exe` next to the current one, **verifies against the release's `SHA256SUMS.txt`** (checksum required — a new executable is never applied unverified), swaps via rename dance (`exe → .old`, `.update → exe`), starts the new instance; leftovers cleaned at startup.
- The sidebar update badge is now a button: **Update to vX** → download with percent progress → **Restart to update**. Failures show inline with the release-page link as fallback.

## 2. OptiScaler auto-update — opt-in, default off
- New config flag `auto_update_optiscaler` + Settings toggle (shown only when update checks are on) with an explanation line.
- At startup, once the scan and the latest-release check have both landed, outdated installs update **sequentially on one worker** (parallel updates would race on the shared download cache). Per-game progress through the existing busy-ops pipeline; `OptiScaler.ini` backed up as in any update.

## 3. Overlay hotkey hint — fixes a real support case
- OptiScaler's overlay opens with Insert, but **non-US keyboard layouts (Danish!) need Alt+Insert** — reported as "overlay doesn't work". The play section now shows the correct hotkey based on `GetKeyboardLayout` (direct user32 extern, no new deps), live per frame so switching layouts updates the hint.

## Verification
- 74 tests green (3 new: SHA256SUMS parsing, swap dance + cleanup, missing-staged failure path)
- `cargo clippy -D warnings` + `cargo fmt --check` clean; release exe builds (7.2 MB)
- i18n: 8 new `ui.*` keys in en/da/pl
- Manual E2E of the full self-update loop requires a newer published release — will be exercised naturally by the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
